### PR TITLE
test: add unit tests for mode/ (update, check, err_mail)

### DIFF
--- a/internal/mode/check.go
+++ b/internal/mode/check.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/Liplus-Project/dipper_ai/internal/config"
-	"github.com/Liplus-Project/dipper_ai/internal/ip"
 	"github.com/Liplus-Project/dipper_ai/internal/state"
 	"github.com/Liplus-Project/dipper_ai/internal/timegate"
 )
@@ -34,7 +33,7 @@ func Check(cfg *config.Config) error {
 		}
 	}
 	if shouldRefresh {
-		fetched, err := ip.Fetch(cfg.IPv4, cfg.IPv6)
+		fetched, err := ipFetch(cfg.IPv4, cfg.IPv6)
 		if err != nil {
 			_ = st.AppendError(fmt.Sprintf("check_ip_fetch_error: %v", err))
 			return err

--- a/internal/mode/check_test.go
+++ b/internal/mode/check_test.go
@@ -1,0 +1,94 @@
+package mode
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Liplus-Project/dipper_ai/internal/config"
+	"github.com/Liplus-Project/dipper_ai/internal/ip"
+	"github.com/Liplus-Project/dipper_ai/internal/state"
+)
+
+func TestCheck_CacheDisabled_AlwaysFetches(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir:    dir,
+		IPv4:        true,
+		DDNSTime:    1,
+		IPCacheTime: 0, // disabled
+	}
+
+	fetchCount := 0
+	orig := ipFetch
+	ipFetch = func(v4, v6 bool) (*ip.Result, error) {
+		fetchCount++
+		return &ip.Result{IPv4: "1.2.3.4"}, nil
+	}
+	t.Cleanup(func() { ipFetch = orig })
+
+	// Run 3 times, resetting the check gate each time so timegate passes.
+	for i := 0; i < 3; i++ {
+		_ = os.Remove(dir + "/gate_check") // reset gate
+		if err := Check(cfg); err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+	}
+	if fetchCount < 3 {
+		t.Errorf("expected at least 3 fetches with IPCacheTime=0, got %d", fetchCount)
+	}
+}
+
+func TestCheck_CacheEnabled_SkipsFetch(t *testing.T) {
+	cfg := &config.Config{
+		StateDir:    t.TempDir(),
+		IPv4:        true,
+		DDNSTime:    1,
+		IPCacheTime: 60, // 60 minutes
+	}
+
+	fetchCount := 0
+	orig := ipFetch
+	ipFetch = func(v4, v6 bool) (*ip.Result, error) {
+		fetchCount++
+		return &ip.Result{IPv4: "1.2.3.4"}, nil
+	}
+	t.Cleanup(func() { ipFetch = orig })
+
+	// First run fetches
+	if err := Check(cfg); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	// Second run should use cached gate (not yet expired)
+	if err := Check(cfg); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if fetchCount > 1 {
+		t.Errorf("expected 1 fetch with cache enabled, got %d", fetchCount)
+	}
+}
+
+func TestCheck_WritesIPToState(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir:    dir,
+		IPv4:        true,
+		DDNSTime:    1,
+		IPCacheTime: 0,
+	}
+
+	orig := ipFetch
+	ipFetch = func(v4, v6 bool) (*ip.Result, error) {
+		return &ip.Result{IPv4: "9.8.7.6"}, nil
+	}
+	t.Cleanup(func() { ipFetch = orig })
+
+	if err := Check(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	st, _ := state.New(dir)
+	got, _ := st.ReadIP("ipv4")
+	if got != "9.8.7.6" {
+		t.Errorf("expected state ipv4=9.8.7.6, got %q", got)
+	}
+}

--- a/internal/mode/errmail.go
+++ b/internal/mode/errmail.go
@@ -11,6 +11,9 @@ import (
 	"github.com/Liplus-Project/dipper_ai/internal/timegate"
 )
 
+// sendMailFn is the mail-sending function; overridable in tests.
+var sendMailFn = sendMail
+
 // ErrMail aggregates errors and sends a notification if the threshold is met.
 // Equivalent to `dipper err_mail`.
 func ErrMail(cfg *config.Config) error {
@@ -43,7 +46,7 @@ func ErrMail(cfg *config.Config) error {
 	body := fmt.Sprintf("dipper_ai error report (%d errors):\n\n%s\n",
 		len(errors), strings.Join(errors, "\n"))
 
-	if err := sendMail(cfg.EmailAddr, "dipper_ai: error notification", body); err != nil {
+	if err := sendMailFn(cfg.EmailAddr, "dipper_ai: error notification", body); err != nil {
 		_ = st.AppendError(fmt.Sprintf("sendmail_failed: %v", err))
 		return fmt.Errorf("sendmail: %w", err)
 	}

--- a/internal/mode/errmail_test.go
+++ b/internal/mode/errmail_test.go
@@ -1,0 +1,104 @@
+package mode
+
+import (
+	"testing"
+
+	"github.com/Liplus-Project/dipper_ai/internal/config"
+	"github.com/Liplus-Project/dipper_ai/internal/state"
+)
+
+func baseCfgErrMail(t *testing.T) *config.Config {
+	t.Helper()
+	return &config.Config{
+		StateDir:     t.TempDir(),
+		ErrChkTime:   1,
+		EmailAddr:    "test@example.com",
+		EmailChkDDNS: true,
+	}
+}
+
+func TestErrMail_Disabled_ErrChkTimeZero(t *testing.T) {
+	cfg := baseCfgErrMail(t)
+	cfg.ErrChkTime = 0
+
+	called := false
+	orig := sendMailFn
+	sendMailFn = func(to, subject, body string) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { sendMailFn = orig })
+
+	if err := ErrMail(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("sendMail should not be called when ErrChkTime=0")
+	}
+}
+
+func TestErrMail_Disabled_NoEmailAddr(t *testing.T) {
+	cfg := baseCfgErrMail(t)
+	cfg.EmailAddr = ""
+
+	called := false
+	orig := sendMailFn
+	sendMailFn = func(to, subject, body string) error { called = true; return nil }
+	t.Cleanup(func() { sendMailFn = orig })
+
+	if err := ErrMail(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("sendMail should not be called with empty EmailAddr")
+	}
+}
+
+func TestErrMail_NoErrors_NoMail(t *testing.T) {
+	cfg := baseCfgErrMail(t)
+
+	called := false
+	orig := sendMailFn
+	sendMailFn = func(to, subject, body string) error { called = true; return nil }
+	t.Cleanup(func() { sendMailFn = orig })
+
+	if err := ErrMail(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("sendMail should not be called when there are no errors")
+	}
+}
+
+func TestErrMail_WithErrors_SendsMail(t *testing.T) {
+	cfg := baseCfgErrMail(t)
+
+	// Write some errors to state
+	st, _ := state.New(cfg.StateDir)
+	_ = st.AppendError("ddns_error mydns[0]: timeout")
+
+	var sentTo, sentBody string
+	orig := sendMailFn
+	sendMailFn = func(to, subject, body string) error {
+		sentTo = to
+		sentBody = body
+		return nil
+	}
+	t.Cleanup(func() { sendMailFn = orig })
+
+	if err := ErrMail(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sentTo != "test@example.com" {
+		t.Errorf("expected recipient test@example.com, got %q", sentTo)
+	}
+	if sentBody == "" {
+		t.Error("expected non-empty mail body")
+	}
+
+	// Errors should be cleared after send
+	errs, _ := st.ReadErrors()
+	if len(errs) != 0 {
+		t.Errorf("expected errors cleared after send, got %d remaining", len(errs))
+	}
+}

--- a/internal/mode/update.go
+++ b/internal/mode/update.go
@@ -12,6 +12,14 @@ import (
 	"github.com/Liplus-Project/dipper_ai/internal/timegate"
 )
 
+// Package-level function variables — overridable in tests.
+var (
+	ipFetch          = ip.Fetch
+	mydnsUpdateIPv4  = ddns.UpdateMyDNSIPv4
+	mydnsUpdateIPv6  = ddns.UpdateMyDNSIPv6
+	cloudflareUpdate = ddns.UpdateCloudflare
+)
+
 // Update is the main DDNS update mode.
 // Equivalent to `dipper update`.
 func Update(cfg *config.Config) error {
@@ -29,7 +37,7 @@ func Update(cfg *config.Config) error {
 	// --- Fetch IPs ---
 	wantV4 := cfg.IPv4 && cfg.IPv4DDNS
 	wantV6 := cfg.IPv6 && cfg.IPv6DDNS
-	fetched, err := ip.Fetch(wantV4, wantV6)
+	fetched, err := ipFetch(wantV4, wantV6)
 	if err != nil {
 		_ = st.AppendError(fmt.Sprintf("ip_fetch_error: %v", err))
 		return err
@@ -78,7 +86,7 @@ func Update(cfg *config.Config) error {
 			Domain: entry.Domain,
 		}
 		if wantV4 && entry.IPv4 && fetched.IPv4 != "" {
-			r := ddns.UpdateMyDNSIPv4(dnsEntry, cfg.MyDNSIPv4URL)
+			r := mydnsUpdateIPv4(dnsEntry, cfg.MyDNSIPv4URL)
 			key := fmt.Sprintf("mydns_%d_ipv4", i)
 			if r.Err != nil {
 				_ = st.WriteDDNSResult(key, "fail:"+r.Err.Error())
@@ -89,7 +97,7 @@ func Update(cfg *config.Config) error {
 			}
 		}
 		if wantV6 && entry.IPv6 && fetched.IPv6 != "" {
-			r := ddns.UpdateMyDNSIPv6(dnsEntry, cfg.MyDNSIPv6URL)
+			r := mydnsUpdateIPv6(dnsEntry, cfg.MyDNSIPv6URL)
 			key := fmt.Sprintf("mydns_%d_ipv6", i)
 			if r.Err != nil {
 				_ = st.WriteDDNSResult(key, "fail:"+r.Err.Error())
@@ -112,7 +120,7 @@ func Update(cfg *config.Config) error {
 			Domain: cf.Domain,
 		}
 		if wantV4 && cf.IPv4 && fetched.IPv4 != "" {
-			r := ddns.UpdateCloudflare(cfEntry, fetched.IPv4, "A", cfg.CloudflareURL)
+			r := cloudflareUpdate(cfEntry, fetched.IPv4, "A", cfg.CloudflareURL)
 			key := fmt.Sprintf("cf_%d_A", i)
 			if r.Err != nil {
 				_ = st.WriteDDNSResult(key, "fail:"+r.Err.Error())
@@ -123,7 +131,7 @@ func Update(cfg *config.Config) error {
 			}
 		}
 		if wantV6 && cf.IPv6 && fetched.IPv6 != "" {
-			r := ddns.UpdateCloudflare(cfEntry, fetched.IPv6, "AAAA", cfg.CloudflareURL)
+			r := cloudflareUpdate(cfEntry, fetched.IPv6, "AAAA", cfg.CloudflareURL)
 			key := fmt.Sprintf("cf_%d_AAAA", i)
 			if r.Err != nil {
 				_ = st.WriteDDNSResult(key, "fail:"+r.Err.Error())

--- a/internal/mode/update_test.go
+++ b/internal/mode/update_test.go
@@ -1,0 +1,171 @@
+package mode
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/Liplus-Project/dipper_ai/internal/config"
+	"github.com/Liplus-Project/dipper_ai/internal/ddns"
+	"github.com/Liplus-Project/dipper_ai/internal/ip"
+)
+
+// fakeFetch returns a fixed IP result.
+func fakeFetch(v4, v6 string) func(bool, bool) (*ip.Result, error) {
+	return func(wantV4, wantV6 bool) (*ip.Result, error) {
+		r := &ip.Result{}
+		if wantV4 {
+			r.IPv4 = v4
+		}
+		if wantV6 {
+			r.IPv6 = v6
+		}
+		return r, nil
+	}
+}
+
+// overrideFetch replaces ipFetch for the duration of a test.
+func overrideFetch(t *testing.T, fn func(bool, bool) (*ip.Result, error)) {
+	t.Helper()
+	orig := ipFetch
+	ipFetch = fn
+	t.Cleanup(func() { ipFetch = orig })
+}
+
+// captureMyDNSCalls replaces mydnsUpdateIPv4/IPv6 and records calls.
+func captureMyDNSCalls(t *testing.T) *[]string {
+	t.Helper()
+	calls := &[]string{}
+	origV4, origV6 := mydnsUpdateIPv4, mydnsUpdateIPv6
+	mydnsUpdateIPv4 = func(e ddns.MyDNSEntry, url string) ddns.ProviderResult {
+		*calls = append(*calls, "ipv4:"+e.Domain)
+		return ddns.ProviderResult{}
+	}
+	mydnsUpdateIPv6 = func(e ddns.MyDNSEntry, url string) ddns.ProviderResult {
+		*calls = append(*calls, "ipv6:"+e.Domain)
+		return ddns.ProviderResult{}
+	}
+	t.Cleanup(func() { mydnsUpdateIPv4 = origV4; mydnsUpdateIPv6 = origV6 })
+	return calls
+}
+
+// baseCfg builds a minimal Config for update tests.
+func baseCfg(t *testing.T) *config.Config {
+	t.Helper()
+	return &config.Config{
+		StateDir:   t.TempDir(),
+		IPv4:       true,
+		IPv4DDNS:   true,
+		UpdateTime: 1,
+		DDNSTime:   1,
+	}
+}
+
+func TestUpdate_NoChange(t *testing.T) {
+	cfg := baseCfg(t)
+	cfg.MyDNS = []config.MyDNSEntry{{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true}}
+
+	// Pre-seed cached IP
+	ip0 := "1.2.3.4"
+	overrideFetch(t, fakeFetch(ip0, ""))
+	calls := captureMyDNSCalls(t)
+
+	// First run: IP written as new
+	if err := Update(cfg); err != nil {
+		t.Fatalf("first run error: %v", err)
+	}
+	firstCalls := len(*calls)
+
+	// Second run with same IP: no DDNS call expected
+	if err := Update(cfg); err != nil {
+		t.Fatalf("second run error: %v", err)
+	}
+	if len(*calls) != firstCalls {
+		t.Errorf("no-change: expected no additional DDNS calls after first run, got %d total", len(*calls))
+	}
+}
+
+func TestUpdate_IPChanged(t *testing.T) {
+	cfg := baseCfg(t)
+	cfg.MyDNS = []config.MyDNSEntry{{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true}}
+
+	calls := captureMyDNSCalls(t)
+
+	// First run
+	overrideFetch(t, fakeFetch("1.2.3.4", ""))
+	if err := Update(cfg); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	// Reset update gate so second run is allowed
+	_ = os.Remove(cfg.StateDir + "/gate_update")
+	_ = os.Remove(cfg.StateDir + "/gate_ddns")
+
+	// Second run with different IP
+	overrideFetch(t, fakeFetch("5.6.7.8", ""))
+	if err := Update(cfg); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	if len(*calls) < 2 {
+		t.Errorf("expected DDNS calls on both runs, got %d", len(*calls))
+	}
+}
+
+func TestUpdate_DDNSError_RecordedInState(t *testing.T) {
+	cfg := baseCfg(t)
+	cfg.MyDNS = []config.MyDNSEntry{{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true}}
+
+	overrideFetch(t, fakeFetch("1.2.3.4", ""))
+
+	orig := mydnsUpdateIPv4
+	mydnsUpdateIPv4 = func(e ddns.MyDNSEntry, url string) ddns.ProviderResult {
+		return ddns.ProviderResult{Err: errors.New("timeout")}
+	}
+	t.Cleanup(func() { mydnsUpdateIPv4 = orig })
+
+	err := Update(cfg)
+	if err == nil {
+		t.Error("expected error from DDNS failure")
+	}
+}
+
+func TestUpdate_PerEntryIPv4IPv6(t *testing.T) {
+	cfg := baseCfg(t)
+	cfg.IPv6 = true
+	cfg.IPv6DDNS = true
+	cfg.MyDNS = []config.MyDNSEntry{
+		{ID: "id0", Pass: "pass0", Domain: "a.example.com", IPv4: true, IPv6: false},
+		{ID: "id1", Pass: "pass1", Domain: "b.example.com", IPv4: false, IPv6: true},
+	}
+
+	overrideFetch(t, fakeFetch("1.2.3.4", "::1"))
+	calls := captureMyDNSCalls(t)
+
+	if err := Update(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	hasV4a := false
+	hasV6b := false
+	for _, c := range *calls {
+		if c == "ipv4:a.example.com" {
+			hasV4a = true
+		}
+		if c == "ipv6:b.example.com" {
+			hasV6b = true
+		}
+	}
+	if !hasV4a {
+		t.Error("expected IPv4 update for a.example.com")
+	}
+	if !hasV6b {
+		t.Error("expected IPv6 update for b.example.com")
+	}
+	// Ensure IPv6 wasn't called for entry[0] (IPv6=false)
+	for _, c := range *calls {
+		if c == "ipv6:a.example.com" {
+			t.Error("IPv6 should be skipped for a.example.com (IPv6=false)")
+		}
+	}
+}


### PR DESCRIPTION
Refs #4

mode/ パッケージのユニットテストを追加。

- 関数変数による依存注入（ip.Fetch / ddns 呼び出し / sendMail）でテスト可能に
- update: IP 変化なし/あり、DDNS エラー記録、per-entry IPv4/IPv6 制御
- check: IPCacheTime=0（常時 fetch）、キャッシュ有効期間スキップ、state 書き込み
- err_mail: 無効ケース、エラーなし、エラーあり（送信・クリア確認）