### PR TITLE
test: add acceptance tests for full binary behavior

### DIFF
--- a/internal/acceptance/binary_test.go
+++ b/internal/acceptance/binary_test.go
@@ -89,7 +89,8 @@ func TestBinary_Check_OutputsIPLine(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Pre-seed ip_cache gate as "just touched" so no dig call is made.
-	ts := fmt.Sprintf("%d\n", time.Now().Unix())
+	// timegate uses time.RFC3339, not a Unix integer.
+	ts := time.Now().Format(time.RFC3339)
 	if err := os.WriteFile(filepath.Join(stateDir, "gate_ip_cache"), []byte(ts), 0644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Refs #8

バイナリを実際にビルドして実行するブラックボックス受け入れテストを追加。
spec (#1) 要件 B「CI 上での比較テスト」を満たす。

- update / check / err_mail / 異常系コマンドの exit code と stdout/stderr を検証
- TestMain でテスト前に `go build` を実行し、全テストで共有