### PR TITLE
docs: add wiki-ready documentation

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,140 @@
+# Architecture
+
+## パッケージ構成
+
+```
+dipper_ai/
+├── cmd/dipper_ai/        # エントリポイント (main.go)
+├── internal/
+│   ├── config/           # 設定ファイルのパース・バリデーション
+│   ├── ddns/             # DDNS プロバイダ実装
+│   ├── ip/               # グローバル IP アドレス取得
+│   ├── lock/             # 多重起動防止ロック
+│   ├── mode/             # コマンドロジック (update / check / err_mail)
+│   ├── state/            # 状態ファイル読み書き
+│   └── timegate/         # タイムゲート（実行間隔制御）
+├── scripts/              # install.sh / uninstall.sh
+└── systemd/              # .service / .timer unit ファイル
+```
+
+---
+
+## 各パッケージの役割
+
+### `config`
+
+`user.conf` を読み込み、`Config` 構造体に変換します。
+
+- shell-style `key=value` 形式、インラインコメント・クォート除去対応
+- `boolVal`: `on` / `off` / `1` / `0` / `true` / `false`（大小文字不問）
+- `intMin`: 最小値を強制（`UPDATE_TIME`、`DDNS_TIME` に使用）
+- `intGate`: `0` = 無効化、それ以外は最小値を強制（`IP_CACHE_TIME`、`ERR_CHK_TIME` に使用）
+- MyDNS エントリは `MYDNS_0_ID` が存在する限りインデックスをインクリメントして解析
+- Cloudflare エントリは `CF_0_ENABLED` が存在する限り同様にインクリメント
+
+```go
+type Config struct {
+    StateDir     string
+    IPv4, IPv6   bool
+    UpdateTime   int  // minutes
+    IPCacheTime  int  // 0 = disabled
+    MyDNS        []MyDNSEntry
+    Cloudflare   []CloudflareEntry
+    // ...
+}
+```
+
+### `ip`
+
+`ip.Fetch(ipv4, ipv6 bool)` でグローバル IP アドレスを取得します。
+外部 HTTP API（`ipv4.icanhazip.com` / `ipv6.icanhazip.com` 等）を使用し、`dig` などの外部コマンドに依存しません。
+
+### `ddns`
+
+DDNS プロバイダごとの HTTP 更新実装。
+
+**MyDNS** (`mydns.go`):
+- `UpdateMyDNSIPv4(entry, url) ProviderResult`
+- `UpdateMyDNSIPv6(entry, url) ProviderResult`
+- HTTP GET + Basic Auth ヘッダ
+
+**Cloudflare** (`cloudflare.go`):
+- `UpdateCloudflare(entry, ip, recordType, zonesURL) ProviderResult`
+- 3 ステップ: ゾーン名 → ゾーン ID 解決 → レコード検索 → PATCH 更新
+- `Authorization: Bearer <token>` ヘッダ
+
+`ProviderResult` は成功・失敗とエラーメッセージを保持します。
+
+### `timegate`
+
+`gate_<name>` ファイルに RFC3339 タイムスタンプを書き込み、前回実行からの経過時間を判定します。
+
+```go
+gate := timegate.New(stateDir, "update", 1440*time.Minute)
+if gate.ShouldRun() {
+    // 実行
+    gate.Touch()
+}
+```
+
+### `state`
+
+IP アドレスや DDNS エラーログを `STATE_DIR` のファイルに保存・読み込みします。
+
+| ファイル名 | 内容 |
+|------------|------|
+| `ip_ipv4` | 最後に取得した IPv4 アドレス |
+| `ip_ipv6` | 最後に取得した IPv6 アドレス |
+| `ddns_errors` | DDNS 更新エラーのログ |
+| `gate_<name>` | タイムゲートのタイムスタンプ（RFC3339） |
+| `lock_<command>` | 多重起動防止ロックファイル |
+
+### `lock`
+
+`lock_<command>` ファイルによる排他ロック。同一コマンドの二重起動を防ぎます。
+
+### `mode`
+
+コマンドごとのロジックを実装します。テスト容易性のため、外部依存（IP 取得・DDNS 更新・メール送信）はパッケージ変数として注入可能にしています。
+
+```go
+var (
+    ipFetch         = ip.Fetch
+    mydnsUpdateIPv4 = ddns.UpdateMyDNSIPv4
+    cloudflareUpdate = ddns.UpdateCloudflare
+)
+```
+
+---
+
+## データフロー（update コマンド）
+
+```
+main()
+  └─ config.Load()              設定読み込み
+  └─ lock.Acquire()             多重起動防止
+  └─ mode.Update(cfg)
+       └─ timegate "update"     UPDATE_TIME ゲート確認
+       └─ ip.Fetch()            グローバル IP 取得
+       └─ state.ReadIP()        前回 IP 読み込み
+       └─ [IP 変化あり]
+            └─ timegate "ddns"  DDNS_TIME ゲート確認
+            └─ ddns.UpdateMyDNSIPv4/IPv6()   MyDNS 更新
+            └─ ddns.UpdateCloudflare()       CF 更新
+            └─ state.WriteIP()  新 IP を保存
+            └─ state.AppendError() エラーがあれば記録
+```
+
+---
+
+## テスト構造
+
+| パッケージ | テスト手法 |
+|------------|-----------|
+| `config` | ユニットテスト（`ParseFile` に文字列を渡す） |
+| `ddns` | `httptest.NewServer` によるHTTPモックサーバ |
+| `mode` | パッケージ変数差し替えによる関数インジェクション |
+| `acceptance` | バイナリをビルドして `exec.Command` で呼び出すブラックボックステスト |
+
+受け入れテストは外部 API・`dig` コマンドに依存しません。
+IP 取得が必要なテストでは `IP_CACHE_TIME > 0` + `gate_ip_cache` ファイルの事前配置でキャッシュヒットパスを使用します。

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,0 +1,167 @@
+# Configuration
+
+設定ファイルは shell-style の `key=value` 形式です。
+デフォルトのパスは `/etc/dipper_ai/user.conf`（`DIPPER_AI_CONFIG` 環境変数で変更可）。
+
+## 書式ルール
+
+```
+KEY=value          # 基本形
+KEY=on             # 真偽値: on / off / 1 / 0 / true / false（大小文字不問）
+KEY=value # memo   # インラインコメント（値に " #" を含めない）
+KEY="value"        # 前後のダブルクォートは自動で除去
+# コメント行       # 行頭 # は無視
+```
+
+---
+
+## STATE_DIR
+
+| | |
+|--|--|
+| **キー** | `STATE_DIR` |
+| **型** | string (ディレクトリパス) |
+| **デフォルト** | `/etc/dipper_ai/state` |
+
+タイムスタンプ・IP キャッシュ・エラーログなどの状態ファイルを保存するディレクトリ。
+存在しない場合は実行時に自動生成されます。
+
+```conf
+STATE_DIR=/etc/dipper_ai/state
+```
+
+---
+
+## IP アドレス設定
+
+| キー | 型 | デフォルト | 説明 |
+|------|----|-----------|------|
+| `IPV4` | bool | `on` | IPv4 アドレスを取得・追跡する |
+| `IPV6` | bool | `off` | IPv6 アドレスを取得・追跡する |
+| `IPV4_DDNS` | bool | `on` | IPv4 で DDNS を更新する（A レコード） |
+| `IPV6_DDNS` | bool | `on` | IPv6 で DDNS を更新する（AAAA レコード） |
+
+```conf
+IPV4=on
+IPV6=off
+IPV4_DDNS=on
+IPV6_DDNS=on
+```
+
+---
+
+## タイムゲート（分単位）
+
+実行間隔を制御します。ゲートファイルが `STATE_DIR` に保存されます。
+
+| キー | デフォルト | 最小値 | 説明 |
+|------|-----------|--------|------|
+| `UPDATE_TIME` | `1440` | 3 | 定期更新の間隔（分） |
+| `DDNS_TIME` | `1` | 1 | IP 変化後に DDNS を更新する間隔（分） |
+| `IP_CACHE_TIME` | `0` | 15（有効時） | IP キャッシュの有効期間（0 = 無効化） |
+| `ERR_CHK_TIME` | `0` | 1（有効時） | エラーメール送信の間隔（0 = 無効化） |
+
+- 設定値が最小値を下回る場合は自動的に最小値に切り上げられます。
+- `0` を設定すると「無効化」として扱われる（`IP_CACHE_TIME`、`ERR_CHK_TIME` のみ）。
+
+```conf
+UPDATE_TIME=1440    # 1日
+DDNS_TIME=1         # 1分
+IP_CACHE_TIME=0     # キャッシュなし（毎回取得）
+ERR_CHK_TIME=0      # エラーメール無効
+```
+
+---
+
+## MyDNS
+
+[MyDNS.JP](https://www.mydns.jp) への更新設定。エントリは `MYDNS_0_*`、`MYDNS_1_*`、`MYDNS_2_*` ... と増やせます。
+
+### エントリキー（`N` = 0, 1, 2, ...）
+
+| キー | 型 | 必須 | デフォルト | 説明 |
+|------|----|------|-----------|------|
+| `MYDNS_N_ID` | string | ✓ | — | MyDNS マスター ID（省略するとそのエントリを終端とみなす） |
+| `MYDNS_N_PASS` | string | ✓ | — | MyDNS パスワード |
+| `MYDNS_N_DOMAIN` | string | | `""` | ドメイン名（現在はログ用途のみ） |
+| `MYDNS_N_IPV4` | bool | | `on` | このエントリで IPv4 を更新する |
+| `MYDNS_N_IPV6` | bool | | `off` | このエントリで IPv6 を更新する |
+
+### URL オーバーライド（省略可）
+
+| キー | デフォルト |
+|------|-----------|
+| `MYDNS_IPV4_URL` | `https://ipv4.mydns.jp/login.html` |
+| `MYDNS_IPV6_URL` | `https://ipv6.mydns.jp/login.html` |
+
+### 例
+
+```conf
+MYDNS_0_ID=mydns123456
+MYDNS_0_PASS=yourpassword
+MYDNS_0_DOMAIN=home.example.com
+MYDNS_0_IPV4=on
+MYDNS_0_IPV6=off
+
+MYDNS_1_ID=mydns789012
+MYDNS_1_PASS=anotherpassword
+MYDNS_1_DOMAIN=server.example.com
+MYDNS_1_IPV4=on
+MYDNS_1_IPV6=on
+```
+
+---
+
+## Cloudflare
+
+Cloudflare DNS への更新設定。エントリは `CF_0_*`、`CF_1_*` ... と増やせます。
+ゾーン名からゾーン ID を自動解決します（ゾーン ID を直接書く必要はありません）。
+
+### エントリキー（`N` = 0, 1, 2, ...）
+
+| キー | 型 | 必須 | デフォルト | 説明 |
+|------|----|------|-----------|------|
+| `CF_N_ENABLED` | bool | ✓ | — | このエントリを有効化（省略するとそのエントリを終端とみなす） |
+| `CF_N_API` | string | 有効時 ✓ | — | Cloudflare API トークン（DNS:Edit 権限） |
+| `CF_N_ZONE` | string | 有効時 ✓ | — | ゾーン名（例: `example.com`） |
+| `CF_N_DOMAIN` | string | 有効時 ✓ | — | 更新対象 FQDN（例: `home.example.com`） |
+| `CF_N_IPV4` | bool | | `on` | A レコードを更新する |
+| `CF_N_IPV6` | bool | | `off` | AAAA レコードを更新する |
+
+### URL オーバーライド（省略可）
+
+| キー | デフォルト |
+|------|-----------|
+| `CLOUDFLARE_URL` | `https://api.cloudflare.com/client/v4/zones` |
+
+### 例
+
+```conf
+CF_0_ENABLED=on
+CF_0_API=your_api_token_here
+CF_0_ZONE=example.com
+CF_0_DOMAIN=home.example.com
+CF_0_IPV4=on
+CF_0_IPV6=off
+```
+
+---
+
+## メール通知
+
+エラーが蓄積された場合に `sendmail` 経由で通知します。
+`EMAIL_CHK_DDNS` または `EMAIL_UP_DDNS` を `on` にする場合、`EMAIL_ADR` は必須です。
+
+| キー | 型 | デフォルト | 説明 |
+|------|----|-----------|------|
+| `EMAIL_CHK_DDNS` | bool | `off` | IP 変化時に通知 |
+| `EMAIL_UP_DDNS` | bool | `off` | 定期更新時に通知 |
+| `EMAIL_ADR` | string | `""` | 通知先メールアドレス |
+
+```conf
+EMAIL_CHK_DDNS=on
+EMAIL_UP_DDNS=off
+EMAIL_ADR=admin@example.com
+```
+
+> **Note:** メール送信は `sendmail` コマンドに依存します。事前にメール送信環境を構築してください。

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,47 @@
+# dipper_ai
+
+**dipper_ai** は AlmaLinux 9/10 向けの DDNS 自動更新ツールです。
+IP アドレスの変化を検知し、MyDNS または Cloudflare の DNS レコードをリアルタイムで更新します。
+systemd タイマーで定期実行し、エラー発生時にはメール通知を送ることができます。
+
+---
+
+## ページ一覧
+
+| ページ | 内容 |
+|--------|------|
+| [Installation](Installation) | ビルド・インストール・アンインストール |
+| [Configuration](Configuration) | `user.conf` 全キー一覧とデフォルト値 |
+| [Usage](Usage) | コマンド仕様と systemd 運用 |
+| [Architecture](Architecture) | 内部設計・パッケージ構成・データフロー |
+
+---
+
+## 特徴
+
+- **マルチプロバイダ**: MyDNS と Cloudflare を同時に複数エントリ管理
+- **IPv4 / IPv6 独立制御**: A レコードと AAAA レコードをエントリごとに ON/OFF
+- **タイムゲート**: 設定した間隔ごとにのみ実行（不要な API 呼び出しを防止）
+- **状態管理**: IP キャッシュ・エラーログをファイルで永続化
+- **外部依存最小**: 標準 Go ライブラリのみ、`dig` 等の外部コマンド不使用
+
+---
+
+## クイックスタート
+
+```bash
+# 1. ビルド
+go build -o dipper_ai ./cmd/dipper_ai
+
+# 2. インストール（root 必要）
+sudo bash scripts/install.sh
+
+# 3. 設定
+sudo cp /etc/dipper_ai/user.conf.example /etc/dipper_ai/user.conf
+sudo vi /etc/dipper_ai/user.conf
+
+# 4. 動作確認
+dipper_ai check
+```
+
+詳細は [Installation](Installation) を参照してください。

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,0 +1,91 @@
+# Installation
+
+## 必要環境
+
+| 項目 | 要件 |
+|------|------|
+| OS | AlmaLinux 9 / 10（他の systemd Linux でも動作可能） |
+| Go | 1.23 以上（ビルド時のみ） |
+| 権限 | インストールスクリプトは root 必要 |
+
+---
+
+## ビルド
+
+```bash
+git clone https://github.com/Liplus-Project/dipper_ai.git
+cd dipper_ai
+go build -o dipper_ai ./cmd/dipper_ai
+```
+
+クロスコンパイル例（Linux AMD64 向け）:
+
+```bash
+GOOS=linux GOARCH=amd64 go build -o dipper_ai ./cmd/dipper_ai
+```
+
+---
+
+## インストール
+
+`scripts/install.sh` を root で実行します。
+以下のファイルが配置され、systemd タイマーが有効化されます。
+
+```bash
+sudo bash scripts/install.sh
+```
+
+### 配置先
+
+| ファイル | 配置先 |
+|----------|--------|
+| `dipper_ai` バイナリ | `/usr/local/bin/dipper_ai` |
+| 設定サンプル | `/etc/dipper_ai/user.conf.example` |
+| systemd サービス | `/etc/systemd/system/dipper_ai.service` |
+| systemd タイマー | `/etc/systemd/system/dipper_ai.timer` |
+| 状態ファイル | `/etc/dipper_ai/state/`（実行時に自動生成） |
+
+### インストール後の手順
+
+```bash
+# 設定ファイルを作成して編集
+sudo cp /etc/dipper_ai/user.conf.example /etc/dipper_ai/user.conf
+sudo vi /etc/dipper_ai/user.conf
+
+# タイマーの状態確認
+systemctl status dipper_ai.timer
+
+# 手動で update を実行してテスト
+sudo dipper_ai update
+```
+
+---
+
+## アンインストール
+
+```bash
+sudo bash scripts/uninstall.sh
+```
+
+サービス・タイマーの停止と無効化、バイナリの削除を行います。
+設定ファイル (`/etc/dipper_ai/`) は保持されます。手動で削除してください。
+
+---
+
+## 設定ファイルのパス
+
+デフォルトは `/etc/dipper_ai/user.conf` ですが、環境変数 `DIPPER_AI_CONFIG` で上書きできます。
+
+```bash
+DIPPER_AI_CONFIG=/path/to/custom.conf dipper_ai update
+```
+
+---
+
+## テスト実行
+
+```bash
+go test ./...
+```
+
+全パッケージのユニットテスト・受け入れテストが実行されます（外部 API 接続不要）。

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -1,0 +1,134 @@
+# Usage
+
+## コマンド
+
+```
+dipper_ai <command>
+```
+
+| コマンド | 説明 |
+|----------|------|
+| `update` | 現在の IP を取得し、変化していれば DDNS を更新する |
+| `check` | 現在の IP と DDNS 状態を stdout に出力する |
+| `err_mail` | 蓄積されたエラーを確認し、条件を満たす場合にメール送信する |
+
+コマンドを省略した場合、または未知のコマンドを指定した場合は usage を stderr に出力して exit 1 します。
+
+---
+
+## update
+
+IP アドレスを取得し、前回から変化があれば DDNS プロバイダに更新リクエストを送ります。
+
+**タイムゲート**: `UPDATE_TIME` 分以内に再実行された場合はスキップします（exit 0）。
+**DDNS ゲート**: 更新後 `DDNS_TIME` 分以内に再更新が抑制されます。
+
+### 動作フロー
+
+1. `gate_update` タイムゲートを確認 → 未経過ならスキップ
+2. 現在の IPv4 / IPv6 を取得（`IPV4` / `IPV6` 設定に従う）
+3. 前回の IP と比較
+4. 変化あり → 各 MyDNS エントリ・各 Cloudflare エントリへ更新リクエスト
+5. 結果を状態ファイルに保存
+
+### 出力例
+
+```
+$ dipper_ai update
+# 変化なし: 出力なし、exit 0
+# IP 変化あり: 各プロバイダへの更新が実行される
+```
+
+---
+
+## check
+
+現在保持している IP アドレスを stdout に出力します。
+IP キャッシュが有効（`IP_CACHE_TIME > 0`）かつキャッシュが新鮮な場合は、状態ファイルの値をそのまま使用します。
+
+**タイムゲート**: `DDNS_TIME` 分以内の再実行はスキップします（exit 0）。
+
+### 出力例
+
+```
+$ dipper_ai check
+ipv4: 203.0.113.42
+ipv6: 2001:db8::1
+```
+
+IPv6 が無効（`IPV6=off`）の場合は `ipv6:` 行は出力されません。
+
+---
+
+## err_mail
+
+`STATE_DIR` に蓄積されたエラーログを確認し、設定された条件で通知メールを送ります。
+
+**無効条件**: `ERR_CHK_TIME=0` または `EMAIL_ADR` が空の場合は何もせず exit 0。
+**タイムゲート**: `ERR_CHK_TIME` 分以内の再実行はスキップします（exit 0）。
+
+エラーログが存在しない場合は何もしません。送信後はエラーログをクリアします。
+
+---
+
+## systemd による自動実行
+
+インストールスクリプトで以下の 2 つの unit が配置されます。
+
+### dipper_ai.timer
+
+```ini
+[Timer]
+OnBootSec=2min          # 起動 2 分後に初回実行
+OnUnitActiveSec=5min    # 以降 5 分ごとに実行
+```
+
+### dipper_ai.service
+
+```ini
+[Service]
+Type=oneshot
+WorkingDirectory=/etc/dipper_ai
+ExecStart=/usr/local/bin/dipper_ai update
+ExecStartPost=/usr/local/bin/dipper_ai check
+ExecStartPost=/usr/local/bin/dipper_ai err_mail
+```
+
+1 回の発火で `update` → `check` → `err_mail` が順番に実行されます。
+各コマンドは自身のタイムゲートを持つため、5 分ごとに起動しても実際の更新は `UPDATE_TIME` 間隔でのみ行われます。
+
+### 操作コマンド
+
+```bash
+# タイマー状態確認
+systemctl status dipper_ai.timer
+
+# 直近のログ確認
+journalctl -u dipper_ai.service -n 50
+
+# 手動で即時実行
+systemctl start dipper_ai.service
+
+# タイマー無効化（停止）
+systemctl disable --now dipper_ai.timer
+
+# タイマー再有効化
+systemctl enable --now dipper_ai.timer
+```
+
+---
+
+## 多重起動防止
+
+同一コマンドの二重起動を防ぐため、`STATE_DIR` にロックファイル（`lock_<command>`）を使用します。
+すでに実行中の場合は `already running` を stderr に出力して **exit 0** します（エラー扱いにしない）。
+
+---
+
+## 設定ファイルのパス変更
+
+```bash
+DIPPER_AI_CONFIG=/path/to/custom.conf dipper_ai update
+```
+
+テスト環境や複数インスタンスの管理に利用できます。


### PR DESCRIPTION
## Summary

Adds a `docs/` folder with 5 Markdown pages ready for GitHub Wiki.

- **Home.md** — overview, feature list, quick start
- **Installation.md** — build, install script, file locations, uninstall
- **Configuration.md** — full reference for every config key with types, defaults, examples
- **Usage.md** — command specs (update / check / err_mail), systemd timer/service, lock behavior
- **Architecture.md** — package layout, data flow diagram, test strategy

## Test plan

- [ ] Verify Markdown renders correctly on GitHub
- [ ] Optionally push to Wiki repo (`git clone https://github.com/Liplus-Project/dipper_ai.wiki.git`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)