### PR TITLE
fix(#11): make IPv4/IPv6 fetch independent; add stderr progress output

### DIFF
--- a/internal/ip/fetch.go
+++ b/internal/ip/fetch.go
@@ -9,32 +9,40 @@ import (
 	"strings"
 )
 
-// Result holds the fetched IP addresses.
+// Result holds the fetched IP addresses and any per-family fetch errors.
+// A non-nil ErrIPv4 / ErrIPv6 means that family failed; the corresponding IP
+// field will be empty.  The other family is unaffected.
 type Result struct {
-	IPv4 string // empty if fetch failed or disabled
-	IPv6 string // empty if fetch failed or disabled
+	IPv4    string // empty if fetch failed or disabled
+	IPv6    string // empty if fetch failed or disabled
+	ErrIPv4 error  // non-nil if IPv4 fetch failed
+	ErrIPv6 error  // non-nil if IPv6 fetch failed
 }
 
 // Fetch retrieves the current public IPs according to the flags.
-// fetchV4 / fetchV6 enable/disable each address family.
-// Returns an error if any enabled address family fails to resolve a valid IP.
+// fetchV4 / fetchV6 enable/disable each address family independently.
+// A failure in one family is stored in Result.ErrIPv4 / Result.ErrIPv6 and
+// does NOT prevent the other family from being fetched.  The returned error
+// is always nil; callers should inspect the per-family Err fields.
 func Fetch(fetchV4, fetchV6 bool) (*Result, error) {
 	r := &Result{}
 
 	if fetchV4 {
-		ip, err := fetchIPv4()
+		ipv4, err := fetchIPv4()
 		if err != nil {
-			return nil, fmt.Errorf("IPv4 fetch failed: %w", err)
+			r.ErrIPv4 = fmt.Errorf("IPv4 fetch failed: %w", err)
+		} else {
+			r.IPv4 = ipv4
 		}
-		r.IPv4 = ip
 	}
 
 	if fetchV6 {
-		ip, err := fetchIPv6()
+		ipv6, err := fetchIPv6()
 		if err != nil {
-			return nil, fmt.Errorf("IPv6 fetch failed: %w", err)
+			r.ErrIPv6 = fmt.Errorf("IPv6 fetch failed: %w", err)
+		} else {
+			r.IPv6 = ipv6
 		}
-		r.IPv6 = ip
 	}
 
 	return r, nil

--- a/internal/mode/update.go
+++ b/internal/mode/update.go
@@ -3,6 +3,7 @@ package mode
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/Liplus-Project/dipper_ai/internal/config"
@@ -31,16 +32,37 @@ func Update(cfg *config.Config) error {
 	// --- Time gate: UPDATE_TIME ---
 	updateGate := timegate.New(cfg.StateDir, "update", time.Duration(cfg.UpdateTime)*time.Minute)
 	if !updateGate.ShouldRun() {
+		fmt.Fprintln(os.Stderr, "dipper_ai update: gate active, skipping")
 		return nil
 	}
 
 	// --- Fetch IPs ---
 	wantV4 := cfg.IPv4 && cfg.IPv4DDNS
 	wantV6 := cfg.IPv6 && cfg.IPv6DDNS
-	fetched, err := ipFetch(wantV4, wantV6)
-	if err != nil {
-		_ = st.AppendError(fmt.Sprintf("ip_fetch_error: %v", err))
-		return err
+	fetched, _ := ipFetch(wantV4, wantV6)
+
+	// Log per-family fetch errors; IPv6 failure alone is non-fatal.
+	if wantV4 && fetched.ErrIPv4 != nil {
+		_ = st.AppendError(fmt.Sprintf("ip_fetch_error ipv4: %v", fetched.ErrIPv4))
+		fmt.Fprintf(os.Stderr, "dipper_ai update: IPv4 fetch failed: %v\n", fetched.ErrIPv4)
+	}
+	if wantV6 && fetched.ErrIPv6 != nil {
+		_ = st.AppendError(fmt.Sprintf("ip_fetch_error ipv6: %v", fetched.ErrIPv6))
+		fmt.Fprintf(os.Stderr, "dipper_ai update: IPv6 fetch failed: %v\n", fetched.ErrIPv6)
+	}
+	// Abort only when nothing usable was fetched at all.
+	if fetched.IPv4 == "" && fetched.IPv6 == "" && (wantV4 || wantV6) {
+		if fetched.ErrIPv4 != nil {
+			return fetched.ErrIPv4
+		}
+		return fetched.ErrIPv6
+	}
+
+	if fetched.IPv4 != "" {
+		fmt.Fprintf(os.Stderr, "dipper_ai update: IPv4=%s\n", fetched.IPv4)
+	}
+	if fetched.IPv6 != "" {
+		fmt.Fprintf(os.Stderr, "dipper_ai update: IPv6=%s\n", fetched.IPv6)
 	}
 
 	// --- IP change detection ---
@@ -66,6 +88,7 @@ func Update(cfg *config.Config) error {
 	}
 
 	if !ipChanged {
+		fmt.Fprintln(os.Stderr, "dipper_ai update: IP unchanged, skipping DDNS")
 		_ = updateGate.Touch()
 		return nil
 	}
@@ -73,6 +96,7 @@ func Update(cfg *config.Config) error {
 	// --- DDNS time gate: DDNS_TIME ---
 	ddnsGate := timegate.New(cfg.StateDir, "ddns", time.Duration(cfg.DDNSTime)*time.Minute)
 	if !ddnsGate.ShouldRun() {
+		fmt.Fprintln(os.Stderr, "dipper_ai update: DDNS gate active, skipping")
 		return nil
 	}
 
@@ -91,9 +115,11 @@ func Update(cfg *config.Config) error {
 			if r.Err != nil {
 				_ = st.WriteDDNSResult(key, "fail:"+r.Err.Error())
 				_ = st.AppendError(fmt.Sprintf("ddns_error mydns[%d] ipv4: %v", i, r.Err))
+				fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv4: FAIL: %v\n", i, entry.Domain, r.Err)
 				updateErr = r.Err
 			} else {
 				_ = st.WriteDDNSResult(key, "ok")
+				fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv4: ok\n", i, entry.Domain)
 			}
 		}
 		if wantV6 && entry.IPv6 && fetched.IPv6 != "" {
@@ -102,9 +128,11 @@ func Update(cfg *config.Config) error {
 			if r.Err != nil {
 				_ = st.WriteDDNSResult(key, "fail:"+r.Err.Error())
 				_ = st.AppendError(fmt.Sprintf("ddns_error mydns[%d] ipv6: %v", i, r.Err))
+				fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv6: FAIL: %v\n", i, entry.Domain, r.Err)
 				updateErr = r.Err
 			} else {
 				_ = st.WriteDDNSResult(key, "ok")
+				fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv6: ok\n", i, entry.Domain)
 			}
 		}
 	}
@@ -125,9 +153,11 @@ func Update(cfg *config.Config) error {
 			if r.Err != nil {
 				_ = st.WriteDDNSResult(key, "fail:"+r.Err.Error())
 				_ = st.AppendError(fmt.Sprintf("ddns_error cloudflare[%d] A: %v", i, r.Err))
+				fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s A: FAIL: %v\n", i, cf.Domain, r.Err)
 				updateErr = r.Err
 			} else {
 				_ = st.WriteDDNSResult(key, "ok")
+				fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s A: ok\n", i, cf.Domain)
 			}
 		}
 		if wantV6 && cf.IPv6 && fetched.IPv6 != "" {
@@ -136,9 +166,11 @@ func Update(cfg *config.Config) error {
 			if r.Err != nil {
 				_ = st.WriteDDNSResult(key, "fail:"+r.Err.Error())
 				_ = st.AppendError(fmt.Sprintf("ddns_error cloudflare[%d] AAAA: %v", i, r.Err))
+				fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s AAAA: FAIL: %v\n", i, cf.Domain, r.Err)
 				updateErr = r.Err
 			} else {
 				_ = st.WriteDDNSResult(key, "ok")
+				fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s AAAA: ok\n", i, cf.Domain)
 			}
 		}
 	}

--- a/internal/mode/update_test.go
+++ b/internal/mode/update_test.go
@@ -24,6 +24,21 @@ func fakeFetch(v4, v6 string) func(bool, bool) (*ip.Result, error) {
 	}
 }
 
+// fakeFetchIPv6Err returns IPv4 successfully but simulates an IPv6 fetch error.
+// This replicates the issue #11 scenario (host has no IPv6 connectivity).
+func fakeFetchIPv6Err(v4 string, v6Err error) func(bool, bool) (*ip.Result, error) {
+	return func(wantV4, wantV6 bool) (*ip.Result, error) {
+		r := &ip.Result{}
+		if wantV4 {
+			r.IPv4 = v4
+		}
+		if wantV6 {
+			r.ErrIPv6 = v6Err
+		}
+		return r, nil
+	}
+}
+
 // overrideFetch replaces ipFetch for the duration of a test.
 func overrideFetch(t *testing.T, fn func(bool, bool) (*ip.Result, error)) {
 	t.Helper()
@@ -127,6 +142,38 @@ func TestUpdate_DDNSError_RecordedInState(t *testing.T) {
 	err := Update(cfg)
 	if err == nil {
 		t.Error("expected error from DDNS failure")
+	}
+}
+
+// TestUpdate_IPv6FetchFail_IPv4Proceeds is the regression test for issue #11.
+// When IPv6 fetch fails (e.g. the host has no IPv6 connectivity), the update
+// must still proceed and update DDNS for IPv4.
+func TestUpdate_IPv6FetchFail_IPv4Proceeds(t *testing.T) {
+	cfg := baseCfg(t)
+	cfg.IPv6 = true
+	cfg.IPv6DDNS = true
+	cfg.MyDNS = []config.MyDNSEntry{
+		{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true, IPv6: true},
+	}
+
+	overrideFetch(t, fakeFetchIPv6Err("1.2.3.4", errors.New("dig ipv6: exit status 1")))
+	calls := captureMyDNSCalls(t)
+
+	if err := Update(cfg); err != nil {
+		t.Fatalf("IPv6 failure should not abort the update: %v", err)
+	}
+
+	hasV4 := false
+	for _, c := range *calls {
+		if c == "ipv4:home.example.com" {
+			hasV4 = true
+		}
+		if c == "ipv6:home.example.com" {
+			t.Error("IPv6 DDNS must not be called when IPv6 fetch failed")
+		}
+	}
+	if !hasV4 {
+		t.Error("IPv4 DDNS must still run even when IPv6 fetch failed")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Root cause of issue #11**: \`ip.Fetch()\` returned a fatal error when IPv6 fetch failed (e.g. host has no IPv6 connectivity), causing the entire update to abort before any DDNS was attempted
- Fixed by making each address family independent: IPv6 failure no longer blocks IPv4 DDNS updates
- Added detailed stderr progress output so operators can see exactly what happened

## Changes

- \`internal/ip/fetch.go\`: \`ip.Result\` gains \`ErrIPv4\`/\`ErrIPv6\` fields; \`Fetch()\` stores per-family errors and always returns a partial result
- \`internal/mode/update.go\`: logs per-family fetch errors to state + stderr; only aborts when nothing was fetched at all; adds progress lines for gate skips, fetched IPs, and per-provider DDNS results
- \`internal/mode/update_test.go\`: adds \`TestUpdate_IPv6FetchFail_IPv4Proceeds\` regression test

## Test plan

- [ ] \`go test ./...\` passes
- [ ] On AlmaLinux with \`IPV4=on IPV6=on\` and no IPv6 connectivity: stderr shows \`IPv6 fetch failed\` but IPv4 DDNS still updates
- [ ] On AlmaLinux with both families available: both update as before

Closes #11