### PR TITLE
fix(update): check IP on every run; UPDATE_TIME = periodic force-sync

### DIFF
--- a/internal/mode/update.go
+++ b/internal/mode/update.go
@@ -29,14 +29,7 @@ func Update(cfg *config.Config) error {
 		return err
 	}
 
-	// --- Time gate: UPDATE_TIME ---
-	updateGate := timegate.New(cfg.StateDir, "update", time.Duration(cfg.UpdateTime)*time.Minute)
-	if !updateGate.ShouldRun() {
-		fmt.Fprintln(os.Stderr, "dipper_ai update: gate active, skipping")
-		return nil
-	}
-
-	// --- Fetch IPs ---
+	// --- Fetch IPs (always — IP must be checked on every run) ---
 	wantV4 := cfg.IPv4 && cfg.IPv4DDNS
 	wantV6 := cfg.IPv6 && cfg.IPv6DDNS
 	fetched, _ := ipFetch(wantV4, wantV6)
@@ -66,6 +59,7 @@ func Update(cfg *config.Config) error {
 	}
 
 	// --- IP change detection ---
+	// Cache is initialised to 0.0.0.0 / :: so first run always triggers DDNS.
 	ipChanged := false
 
 	if fetched.IPv4 != "" {
@@ -87,15 +81,25 @@ func Update(cfg *config.Config) error {
 		}
 	}
 
-	if !ipChanged {
+	// UPDATE_TIME: force re-sync even when IP is unchanged (catches external
+	// DDNS edits).  ipChanged bypasses this gate so IP changes are acted on
+	// immediately regardless of how recently the last sync ran.
+	updateGate := timegate.New(cfg.StateDir, "update", time.Duration(cfg.UpdateTime)*time.Minute)
+	forceSync := updateGate.ShouldRun()
+
+	if !ipChanged && !forceSync {
 		fmt.Fprintln(os.Stderr, "dipper_ai update: IP unchanged, skipping DDNS")
-		_ = updateGate.Touch()
 		return nil
+	}
+	if !ipChanged && forceSync {
+		fmt.Fprintln(os.Stderr, "dipper_ai update: forcing periodic re-sync")
 	}
 
 	// --- DDNS time gate: DDNS_TIME ---
+	// Bypassed on force-sync: if UPDATE_TIME (e.g. 24h) has elapsed then
+	// DDNS_TIME (e.g. 3min) has certainly elapsed too.
 	ddnsGate := timegate.New(cfg.StateDir, "ddns", time.Duration(cfg.DDNSTime)*time.Minute)
-	if !ddnsGate.ShouldRun() {
+	if !forceSync && !ddnsGate.ShouldRun() {
 		fmt.Fprintln(os.Stderr, "dipper_ai update: DDNS gate active, skipping")
 		return nil
 	}
@@ -175,7 +179,9 @@ func Update(cfg *config.Config) error {
 		}
 	}
 
-	_ = updateGate.Touch()
+	if forceSync {
+		_ = updateGate.Touch()
+	}
 	_ = ddnsGate.Touch()
 	return updateErr
 }

--- a/internal/mode/update_test.go
+++ b/internal/mode/update_test.go
@@ -177,6 +177,62 @@ func TestUpdate_IPv6FetchFail_IPv4Proceeds(t *testing.T) {
 	}
 }
 
+// TestUpdate_ForceSync verifies that UPDATE_TIME triggers a DDNS re-sync even
+// when the IP has not changed (catches external DDNS edits / drift).
+func TestUpdate_ForceSync(t *testing.T) {
+	cfg := baseCfg(t)
+	cfg.MyDNS = []config.MyDNSEntry{{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true}}
+
+	overrideFetch(t, fakeFetch("1.2.3.4", ""))
+	calls := captureMyDNSCalls(t)
+
+	// First run — IP written to cache, DDNS called.
+	if err := Update(cfg); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	after1 := len(*calls)
+	if after1 == 0 {
+		t.Fatal("expected DDNS call on first run")
+	}
+
+	// Second run — same IP, gate_update still active → skip.
+	if err := Update(cfg); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if len(*calls) != after1 {
+		t.Errorf("expected no DDNS call when IP unchanged and gate active")
+	}
+
+	// Remove only the update gate to simulate UPDATE_TIME elapsed.
+	_ = os.Remove(cfg.StateDir + "/gate_update")
+
+	// Third run — same IP, but force-sync gate elapsed → DDNS must be called.
+	if err := Update(cfg); err != nil {
+		t.Fatalf("force-sync run: %v", err)
+	}
+	if len(*calls) <= after1 {
+		t.Errorf("expected DDNS call on force-sync run (IP unchanged but UPDATE_TIME elapsed)")
+	}
+}
+
+// TestUpdate_InitialCacheIsZero verifies that a fresh install (no state files)
+// always triggers a DDNS update, because the implicit cache is 0.0.0.0.
+func TestUpdate_InitialCacheIsZero(t *testing.T) {
+	cfg := baseCfg(t)
+	cfg.MyDNS = []config.MyDNSEntry{{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true}}
+
+	overrideFetch(t, fakeFetch("1.2.3.4", ""))
+	calls := captureMyDNSCalls(t)
+
+	// State dir is empty (t.TempDir) — no ip_ipv4 file exists.
+	if err := Update(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(*calls) == 0 {
+		t.Error("expected DDNS call on first run with empty state (cache=0.0.0.0)")
+	}
+}
+
 func TestUpdate_PerEntryIPv4IPv6(t *testing.T) {
 	cfg := baseCfg(t)
 	cfg.IPv6 = true

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -23,11 +23,15 @@ func New(dir string) (*Manager, error) {
 }
 
 // ReadIP returns the cached IP for the given key ("ipv4" or "ipv6").
-// Returns ("", nil) if not cached.
+// Returns ("0.0.0.0" / "::" , nil) when not yet cached so that any real
+// IP address is always treated as a change on first run.
 func (m *Manager) ReadIP(key string) (string, error) {
 	data, err := os.ReadFile(m.path("ip_" + key))
 	if os.IsNotExist(err) {
-		return "", nil
+		if key == "ipv6" {
+			return "::", nil
+		}
+		return "0.0.0.0", nil
 	}
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## 問題

UPDATE_TIME ゲートが IP フェッチ自体をブロックしていたため、IP は UPDATE_TIME 分に一度しかチェックされなかった。タイマーが 3 分ごとに起動しても意味がなかった。

## 修正後の動作

- IP フェッチは**毎回必ず実行**（ゲートなし）
- IP 変化 → 即座に DDNS 更新（DDNS_TIME ゲートも通過）
- IP 変化なし + UPDATE_TIME 経過 → **強制 re-sync**（外部での DDNS 書き換えをリカバリ）
- IP 変化なし + UPDATE_TIME 未経過 → スキップ
- `state.ReadIP` の初期値を `0.0.0.0` / `::` に変更 → 初回必ず更新

## テスト追加

- `TestUpdate_ForceSync` : IP 不変でも UPDATE_TIME 経過で DDNS が呼ばれることを確認
- `TestUpdate_InitialCacheIsZero` : キャッシュなし状態で必ず初回更新されることを確認