### PR TITLE
fix(check+update): DNS verify + DDNS gate bypass on IP change

### DIFF
--- a/internal/acceptance/binary_test.go
+++ b/internal/acceptance/binary_test.go
@@ -78,29 +78,20 @@ func TestBinary_Update_ExitZero(t *testing.T) {
 	}
 }
 
-func TestBinary_Check_OutputsIPLine(t *testing.T) {
+func TestBinary_Check_GatedExitZero(t *testing.T) {
 	stateDir := t.TempDir()
-	// IPV4=on with a positive cache time so check reads the cached IP
-	// without calling dig. IPV6 stays off.
-	conf := writeConf(t, stateDir, "IPV4=on\nIP_CACHE_TIME=60\n")
+	// check uses UpdateTime as its gate duration (default 1440 min).
+	conf := writeConf(t, stateDir, "IPV4=on\n")
 
-	// Pre-seed cached IP state.
-	if err := os.WriteFile(filepath.Join(stateDir, "ip_ipv4"), []byte("1.2.3.4\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	// Pre-seed ip_cache gate as "just touched" so no dig call is made.
-	// timegate uses time.RFC3339, not a Unix integer.
+	// Pre-seed gate_check as "just touched" so check skips without network.
 	ts := time.Now().Format(time.RFC3339)
-	if err := os.WriteFile(filepath.Join(stateDir, "gate_ip_cache"), []byte(ts), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(stateDir, "gate_check"), []byte(ts), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	stdout, _, code := runBinary(t, conf, "check")
+	_, _, code := runBinary(t, conf, "check")
 	if code != 0 {
-		t.Errorf("expected exit 0 for check, got %d", code)
-	}
-	if !strings.Contains(stdout, "ipv4:") {
-		t.Errorf("expected stdout to contain 'ipv4:', got: %q", stdout)
+		t.Errorf("expected exit 0 for gated check, got %d", code)
 	}
 }
 

--- a/internal/mode/check.go
+++ b/internal/mode/check.go
@@ -2,6 +2,8 @@ package mode
 
 import (
 	"fmt"
+	"net"
+	"os"
 	"time"
 
 	"github.com/Liplus-Project/dipper_ai/internal/config"
@@ -9,53 +11,157 @@ import (
 	"github.com/Liplus-Project/dipper_ai/internal/timegate"
 )
 
-// Check reports the current IP and cached DDNS state.
+// Package-level DNS lookup functions — overridable in tests.
+var (
+	dnsLookupA    = lookupARecord
+	dnsLookupAAAA = lookupAAAARecord
+)
+
+// Check resolves the DNS-registered IP for each configured DDNS domain and
+// compares it with the current external IP.  If any domain has a stale or
+// wrong registration, Check resets the IP cache and forces an immediate DDNS
+// update via Update().
+//
 // Equivalent to `dipper check`.
 func Check(cfg *config.Config) error {
-	st, err := state.New(cfg.StateDir)
-	if err != nil {
-		return err
-	}
-
-	// --- Time gate: DDNS_TIME (check gate) ---
-	checkGate := timegate.New(cfg.StateDir, "check", time.Duration(cfg.DDNSTime)*time.Minute)
+	// Check runs on its own schedule — use UpdateTime so it does not fire on
+	// every timer tick (which would cause spurious DNS lookups and race
+	// conditions immediately after a fresh update).
+	checkGate := timegate.New(cfg.StateDir, "check", time.Duration(cfg.UpdateTime)*time.Minute)
 	if !checkGate.ShouldRun() {
 		return nil
 	}
 
-	// --- IP cache gate (0 = disabled: always refresh) ---
-	shouldRefresh := true
-	if cfg.IPCacheTime > 0 {
-		ipCacheGate := timegate.New(cfg.StateDir, "ip_cache", time.Duration(cfg.IPCacheTime)*time.Minute)
-		shouldRefresh = ipCacheGate.ShouldRun()
-		if shouldRefresh {
-			defer func() { _ = ipCacheGate.Touch() }()
-		}
+	wantV4 := cfg.IPv4 && cfg.IPv4DDNS
+	wantV6 := cfg.IPv6 && cfg.IPv6DDNS
+
+	// Fetch current external IP.
+	fetched, _ := ipFetch(wantV4, wantV6)
+	if wantV4 && fetched.ErrIPv4 != nil {
+		fmt.Fprintf(os.Stderr, "dipper_ai check: IPv4 fetch error: %v\n", fetched.ErrIPv4)
 	}
-	if shouldRefresh {
-		fetched, err := ipFetch(cfg.IPv4, cfg.IPv6)
-		if err != nil {
-			_ = st.AppendError(fmt.Sprintf("check_ip_fetch_error: %v", err))
-			return err
+	if wantV6 && fetched.ErrIPv6 != nil {
+		fmt.Fprintf(os.Stderr, "dipper_ai check: IPv6 fetch error: %v\n", fetched.ErrIPv6)
+	}
+	if fetched.IPv4 == "" && fetched.IPv6 == "" && (wantV4 || wantV6) {
+		return fmt.Errorf("check: could not fetch current external IP")
+	}
+
+	mismatch := false
+
+	// --- Verify MyDNS domains ---
+	for _, m := range cfg.MyDNS {
+		if m.Domain == "" {
+			continue
 		}
-		if fetched.IPv4 != "" {
-			_ = st.WriteIP("ipv4", fetched.IPv4)
+		if wantV4 && m.IPv4 && fetched.IPv4 != "" {
+			registered, err := dnsLookupA(m.Domain)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "dipper_ai check: DNS A %s: %v → scheduling update\n", m.Domain, err)
+				mismatch = true
+			} else if registered != fetched.IPv4 {
+				fmt.Fprintf(os.Stderr, "dipper_ai check: %s A=%s want=%s → mismatch\n", m.Domain, registered, fetched.IPv4)
+				mismatch = true
+			} else {
+				fmt.Fprintf(os.Stderr, "dipper_ai check: %s A=%s ok\n", m.Domain, registered)
+			}
 		}
-		if fetched.IPv6 != "" {
-			_ = st.WriteIP("ipv6", fetched.IPv6)
+		if wantV6 && m.IPv6 && fetched.IPv6 != "" {
+			registered, err := dnsLookupAAAA(m.Domain)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "dipper_ai check: DNS AAAA %s: %v → scheduling update\n", m.Domain, err)
+				mismatch = true
+			} else if registered != fetched.IPv6 {
+				fmt.Fprintf(os.Stderr, "dipper_ai check: %s AAAA=%s want=%s → mismatch\n", m.Domain, registered, fetched.IPv6)
+				mismatch = true
+			} else {
+				fmt.Fprintf(os.Stderr, "dipper_ai check: %s AAAA=%s ok\n", m.Domain, registered)
+			}
 		}
 	}
 
-	// Output current state to stdout
-	if cfg.IPv4 {
-		v4, _ := st.ReadIP("ipv4")
-		fmt.Printf("ipv4: %s\n", v4)
-	}
-	if cfg.IPv6 {
-		v6, _ := st.ReadIP("ipv6")
-		fmt.Printf("ipv6: %s\n", v6)
+	// --- Verify Cloudflare domains ---
+	for _, cf := range cfg.Cloudflare {
+		if !cf.Enabled || cf.Domain == "" {
+			continue
+		}
+		if wantV4 && cf.IPv4 && fetched.IPv4 != "" {
+			registered, err := dnsLookupA(cf.Domain)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "dipper_ai check: DNS A %s: %v → scheduling update\n", cf.Domain, err)
+				mismatch = true
+			} else if registered != fetched.IPv4 {
+				fmt.Fprintf(os.Stderr, "dipper_ai check: %s A=%s want=%s → mismatch\n", cf.Domain, registered, fetched.IPv4)
+				mismatch = true
+			} else {
+				fmt.Fprintf(os.Stderr, "dipper_ai check: %s A=%s ok\n", cf.Domain, registered)
+			}
+		}
+		if wantV6 && cf.IPv6 && fetched.IPv6 != "" {
+			registered, err := dnsLookupAAAA(cf.Domain)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "dipper_ai check: DNS AAAA %s: %v → scheduling update\n", cf.Domain, err)
+				mismatch = true
+			} else if registered != fetched.IPv6 {
+				fmt.Fprintf(os.Stderr, "dipper_ai check: %s AAAA=%s want=%s → mismatch\n", cf.Domain, registered, fetched.IPv6)
+				mismatch = true
+			} else {
+				fmt.Fprintf(os.Stderr, "dipper_ai check: %s AAAA=%s ok\n", cf.Domain, registered)
+			}
+		}
 	}
 
+	if !mismatch {
+		fmt.Fprintln(os.Stderr, "dipper_ai check: all domains match current IP")
+		_ = checkGate.Touch()
+		return nil
+	}
+
+	// Mismatch detected: reset IP cache so Update() sees a change and pushes
+	// the correct IP to all DDNS providers immediately.
+	fmt.Fprintln(os.Stderr, "dipper_ai check: mismatch detected — forcing DDNS update")
+	st, err := state.New(cfg.StateDir)
+	if err != nil {
+		return err
+	}
+	if wantV4 && fetched.IPv4 != "" {
+		_ = st.WriteIP("ipv4", "0.0.0.0")
+	}
+	if wantV6 && fetched.IPv6 != "" {
+		_ = st.WriteIP("ipv6", "::")
+	}
+
+	updateErr := Update(cfg)
 	_ = checkGate.Touch()
-	return nil
+	return updateErr
+}
+
+// lookupARecord resolves the IPv4 A record for domain.
+func lookupARecord(domain string) (string, error) {
+	ips, err := net.LookupHost(domain)
+	if err != nil {
+		return "", err
+	}
+	for _, s := range ips {
+		if ip := net.ParseIP(s); ip != nil {
+			if v4 := ip.To4(); v4 != nil {
+				return v4.String(), nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no A record for %s", domain)
+}
+
+// lookupAAAARecord resolves the IPv6 AAAA record for domain.
+func lookupAAAARecord(domain string) (string, error) {
+	ips, err := net.LookupHost(domain)
+	if err != nil {
+		return "", err
+	}
+	for _, s := range ips {
+		if ip := net.ParseIP(s); ip != nil && ip.To4() == nil {
+			return ip.String(), nil
+		}
+	}
+	return "", fmt.Errorf("no AAAA record for %s", domain)
 }

--- a/internal/mode/check_test.go
+++ b/internal/mode/check_test.go
@@ -1,94 +1,252 @@
 package mode
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/Liplus-Project/dipper_ai/internal/config"
+	"github.com/Liplus-Project/dipper_ai/internal/ddns"
 	"github.com/Liplus-Project/dipper_ai/internal/ip"
 	"github.com/Liplus-Project/dipper_ai/internal/state"
 )
 
-func TestCheck_CacheDisabled_AlwaysFetches(t *testing.T) {
-	dir := t.TempDir()
-	cfg := &config.Config{
-		StateDir:    dir,
-		IPv4:        true,
-		DDNSTime:    1,
-		IPCacheTime: 0, // disabled
-	}
+// resetCheckGate removes the check gate file so the next Check() call runs.
+func resetCheckGate(dir string) {
+	_ = os.Remove(dir + "/gate_check")
+}
 
-	fetchCount := 0
-	orig := ipFetch
-	ipFetch = func(v4, v6 bool) (*ip.Result, error) {
-		fetchCount++
-		return &ip.Result{IPv4: "1.2.3.4"}, nil
-	}
-	t.Cleanup(func() { ipFetch = orig })
-
-	// Run 3 times, resetting the check gate each time so timegate passes.
-	for i := 0; i < 3; i++ {
-		_ = os.Remove(dir + "/gate_check") // reset gate
-		if err := Check(cfg); err != nil {
-			t.Fatalf("run %d: %v", i, err)
-		}
-	}
-	if fetchCount < 3 {
-		t.Errorf("expected at least 3 fetches with IPCacheTime=0, got %d", fetchCount)
+// fakeFetchIP returns a fixed IPv4.
+func fakeFetchIP(addr string) func(bool, bool) (*ip.Result, error) {
+	return func(v4, v6 bool) (*ip.Result, error) {
+		return &ip.Result{IPv4: addr}, nil
 	}
 }
 
-func TestCheck_CacheEnabled_SkipsFetch(t *testing.T) {
-	cfg := &config.Config{
-		StateDir:    t.TempDir(),
-		IPv4:        true,
-		DDNSTime:    1,
-		IPCacheTime: 60, // 60 minutes
-	}
-
-	fetchCount := 0
-	orig := ipFetch
-	ipFetch = func(v4, v6 bool) (*ip.Result, error) {
-		fetchCount++
-		return &ip.Result{IPv4: "1.2.3.4"}, nil
-	}
-	t.Cleanup(func() { ipFetch = orig })
-
-	// First run fetches
-	if err := Check(cfg); err != nil {
-		t.Fatalf("first run: %v", err)
-	}
-	// Second run should use cached gate (not yet expired)
-	if err := Check(cfg); err != nil {
-		t.Fatalf("second run: %v", err)
-	}
-	if fetchCount > 1 {
-		t.Errorf("expected 1 fetch with cache enabled, got %d", fetchCount)
-	}
+// noopMyDNS is a DDNS update stub that succeeds silently.
+func noopMyDNS(_ ddns.MyDNSEntry, _ string) ddns.ProviderResult {
+	return ddns.ProviderResult{}
 }
 
-func TestCheck_WritesIPToState(t *testing.T) {
+// noopCloudflare is a Cloudflare update stub that succeeds silently.
+func noopCloudflare(_ ddns.CloudflareEntry, _, _, _ string) ddns.ProviderResult {
+	return ddns.ProviderResult{}
+}
+
+// TestCheck_AllMatch_NoUpdate verifies that when DNS matches the current IP,
+// no DDNS update is triggered and the gate is touched.
+func TestCheck_AllMatch_NoUpdate(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{
-		StateDir:    dir,
-		IPv4:        true,
-		DDNSTime:    1,
-		IPCacheTime: 0,
+		StateDir:   dir,
+		IPv4:       true,
+		IPv4DDNS:   true,
+		UpdateTime: 1440,
+		DDNSTime:   1,
+		MyDNS: []config.MyDNSEntry{
+			{ID: "u", Pass: "p", Domain: "home.example.com", IPv4: true},
+		},
 	}
 
-	orig := ipFetch
-	ipFetch = func(v4, v6 bool) (*ip.Result, error) {
-		return &ip.Result{IPv4: "9.8.7.6"}, nil
+	origFetch := ipFetch
+	ipFetch = fakeFetchIP("1.2.3.4")
+	t.Cleanup(func() { ipFetch = origFetch })
+
+	origDNS := dnsLookupA
+	dnsLookupA = func(domain string) (string, error) { return "1.2.3.4", nil } // matches
+	t.Cleanup(func() { dnsLookupA = origDNS })
+
+	origMyDNS := mydnsUpdateIPv4
+	updateCalled := false
+	mydnsUpdateIPv4 = func(e ddns.MyDNSEntry, u string) ddns.ProviderResult {
+		updateCalled = true
+		return ddns.ProviderResult{}
 	}
-	t.Cleanup(func() { ipFetch = orig })
+	t.Cleanup(func() { mydnsUpdateIPv4 = origMyDNS })
 
 	if err := Check(cfg); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if updateCalled {
+		t.Error("DDNS update should NOT have been called when DNS matches")
+	}
+}
 
+// TestCheck_Mismatch_ForcesUpdate verifies that when the DNS-registered IP
+// differs from the current external IP, Check resets the cache and forces an
+// immediate DDNS update.
+func TestCheck_Mismatch_ForcesUpdate(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir:   dir,
+		IPv4:       true,
+		IPv4DDNS:   true,
+		UpdateTime: 1440,
+		DDNSTime:   1,
+		MyDNS: []config.MyDNSEntry{
+			{ID: "u", Pass: "p", Domain: "home.example.com", IPv4: true},
+		},
+		MyDNSIPv4URL: "http://fake.invalid/login.html",
+	}
+
+	// Pre-set cache to current IP so Update() detects the reset to 0.0.0.0.
 	st, _ := state.New(dir)
+	_ = st.WriteIP("ipv4", "1.2.3.4")
+
+	origFetch := ipFetch
+	ipFetch = fakeFetchIP("1.2.3.4") // current IP
+	t.Cleanup(func() { ipFetch = origFetch })
+
+	origDNS := dnsLookupA
+	dnsLookupA = func(domain string) (string, error) { return "0.0.0.0", nil } // stale
+	t.Cleanup(func() { dnsLookupA = origDNS })
+
+	origMyDNS := mydnsUpdateIPv4
+	updateCalled := false
+	mydnsUpdateIPv4 = func(e ddns.MyDNSEntry, u string) ddns.ProviderResult {
+		updateCalled = true
+		return ddns.ProviderResult{}
+	}
+	t.Cleanup(func() { mydnsUpdateIPv4 = origMyDNS })
+
+	if err := Check(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !updateCalled {
+		t.Error("DDNS update SHOULD have been called when DNS is stale")
+	}
+
+	// Verify that IP cache was written with correct IP after update.
 	got, _ := st.ReadIP("ipv4")
-	if got != "9.8.7.6" {
-		t.Errorf("expected state ipv4=9.8.7.6, got %q", got)
+	if got != "1.2.3.4" {
+		t.Errorf("expected cache ipv4=1.2.3.4 after update, got %q", got)
+	}
+}
+
+// TestCheck_DNSError_ForcesUpdate verifies that a DNS lookup failure is
+// treated as a mismatch and triggers a DDNS update.
+func TestCheck_DNSError_ForcesUpdate(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir:   dir,
+		IPv4:       true,
+		IPv4DDNS:   true,
+		UpdateTime: 1440,
+		DDNSTime:   1,
+		MyDNS: []config.MyDNSEntry{
+			{ID: "u", Pass: "p", Domain: "home.example.com", IPv4: true},
+		},
+		MyDNSIPv4URL: "http://fake.invalid/login.html",
+	}
+
+	origFetch := ipFetch
+	ipFetch = fakeFetchIP("5.6.7.8")
+	t.Cleanup(func() { ipFetch = origFetch })
+
+	origDNS := dnsLookupA
+	dnsLookupA = func(domain string) (string, error) { return "", fmt.Errorf("nxdomain") }
+	t.Cleanup(func() { dnsLookupA = origDNS })
+
+	origMyDNS := mydnsUpdateIPv4
+	updateCalled := false
+	mydnsUpdateIPv4 = func(e ddns.MyDNSEntry, u string) ddns.ProviderResult {
+		updateCalled = true
+		return ddns.ProviderResult{}
+	}
+	t.Cleanup(func() { mydnsUpdateIPv4 = origMyDNS })
+
+	if err := Check(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !updateCalled {
+		t.Error("DDNS update SHOULD have been called when DNS lookup fails")
+	}
+}
+
+// TestCheck_Gate_SkipsWhenRecent verifies that the check gate prevents
+// re-running before UpdateTime minutes have elapsed.
+func TestCheck_Gate_SkipsWhenRecent(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir:   dir,
+		IPv4:       true,
+		IPv4DDNS:   true,
+		UpdateTime: 1440,
+		DDNSTime:   1,
+		MyDNS: []config.MyDNSEntry{
+			{ID: "u", Pass: "p", Domain: "home.example.com", IPv4: true},
+		},
+	}
+
+	origFetch := ipFetch
+	fetchCount := 0
+	ipFetch = func(v4, v6 bool) (*ip.Result, error) {
+		fetchCount++
+		return &ip.Result{IPv4: "1.2.3.4"}, nil
+	}
+	t.Cleanup(func() { ipFetch = origFetch })
+
+	origDNS := dnsLookupA
+	dnsLookupA = func(domain string) (string, error) { return "1.2.3.4", nil }
+	t.Cleanup(func() { dnsLookupA = origDNS })
+
+	// First run: gate passes, fetch occurs.
+	if err := Check(cfg); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	// Second run: gate active (not enough time has passed) → skips.
+	if err := Check(cfg); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if fetchCount > 1 {
+		t.Errorf("expected 1 fetch (gate should block second run), got %d", fetchCount)
+	}
+}
+
+// TestUpdate_DDNSGate_BypassedOnIPChange verifies that a real IP change
+// bypasses the DDNS_TIME gate even when the gate is still active.
+func TestUpdate_DDNSGate_BypassedOnIPChange(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		StateDir:     dir,
+		IPv4:         true,
+		IPv4DDNS:     true,
+		UpdateTime:   1440,
+		DDNSTime:     1440, // very long — gate stays active
+		MyDNSIPv4URL: "http://fake.invalid/login.html",
+		MyDNS: []config.MyDNSEntry{
+			{ID: "u", Pass: "p", Domain: "home.example.com", IPv4: true},
+		},
+	}
+
+	// Pre-cache an old IP so the first update() run touches the ddnsGate.
+	st, _ := state.New(dir)
+	_ = st.WriteIP("ipv4", "1.1.1.1")
+
+	origFetch := ipFetch
+	ipFetch = fakeFetchIP("1.1.1.1") // no change yet
+	t.Cleanup(func() { ipFetch = origFetch })
+
+	origMyDNS := mydnsUpdateIPv4
+	callCount := 0
+	mydnsUpdateIPv4 = func(e ddns.MyDNSEntry, u string) ddns.ProviderResult {
+		callCount++
+		return ddns.ProviderResult{}
+	}
+	t.Cleanup(func() { mydnsUpdateIPv4 = origMyDNS })
+
+	// First update: IP unchanged → gate should block (DDNSTime=1440 → gate active after touch)
+	// Actually on first run gate_ddns doesn't exist yet → ShouldRun=true → update fires
+	_ = Update(cfg)
+	after1 := callCount
+
+	// Now simulate IP change — gate_ddns is now active (just touched).
+	ipFetch = fakeFetchIP("9.9.9.9") // new IP
+
+	_ = Update(cfg)
+	after2 := callCount
+
+	if after2 <= after1 {
+		t.Errorf("IP change should bypass DDNS gate; callCount before=%d after=%d", after1, after2)
 	}
 }

--- a/internal/mode/update.go
+++ b/internal/mode/update.go
@@ -96,10 +96,10 @@ func Update(cfg *config.Config) error {
 	}
 
 	// --- DDNS time gate: DDNS_TIME ---
-	// Bypassed on force-sync: if UPDATE_TIME (e.g. 24h) has elapsed then
-	// DDNS_TIME (e.g. 3min) has certainly elapsed too.
+	// Bypassed when IP has changed (act immediately) or when force-sync is set.
+	// Only applies when IP is unchanged and no force-sync requested.
 	ddnsGate := timegate.New(cfg.StateDir, "ddns", time.Duration(cfg.DDNSTime)*time.Minute)
-	if !forceSync && !ddnsGate.ShouldRun() {
+	if !ipChanged && !forceSync && !ddnsGate.ShouldRun() {
 		fmt.Fprintln(os.Stderr, "dipper_ai update: DDNS gate active, skipping")
 		return nil
 	}


### PR DESCRIPTION
## 概要

- **check.go を全面書き直し**: DDNS サーバー側の実際の IP を DNS ルックアップで確認するように変更
- **update.go の DDNS ゲートバグ修正**: IP が変化したときにゲートをバイパスするよう修正

## 変更内容

### check.go

旧実装は外部 IP をキャッシュに書くだけで、DDNS サーバーに実際に何が登録されているかを確認していなかった。

新実装:
1. 現在の外部 IP を取得
2. 設定された全ドメインの A/AAAA レコードを DNS 解決
3. 外部 IP と不一致なら: キャッシュを 0.0.0.0/:: にリセットして Update() を強制実行
4. UpdateTime を check 専用ゲートとして使用（頻繁な DNS 解決を防ぐ）

### update.go

旧: `\!forceSync && \!ddnsGate.ShouldRun()` → IP が変わっても gate がアクティブならスキップ（バグ）

新: `\!ipChanged && \!forceSync && \!ddnsGate.ShouldRun()` → IP 変化時は gate をバイパスして即座に更新

## テスト

- TestCheck_AllMatch_NoUpdate
- TestCheck_Mismatch_ForcesUpdate
- TestCheck_DNSError_ForcesUpdate
- TestCheck_Gate_SkipsWhenRecent
- TestUpdate_DDNSGate_BypassedOnIPChange

Closes #22