### PR TITLE
fix(cloudflare): add CF_x_ZONE_ID to bypass zone-name lookup

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ type CloudflareEntry struct {
 	Enabled bool
 	API     string // API token (DNS:Edit permission)
 	Zone    string // zone name  (e.g. "example.com")
+	ZoneID  string // zone ID (optional, skips zone name lookup when set)
 	Domain  string // FQDN to update (e.g. "home.example.com")
 	IPv4    bool
 	IPv6    bool
@@ -241,6 +242,7 @@ func buildConfig(kv map[string]string) (*Config, error) {
 			Enabled: boolVal(prefix+"ENABLED", false),
 			API:     strOr(prefix+"API", ""),
 			Zone:    strOr(prefix+"ZONE", ""),
+			ZoneID:  strOr(prefix+"ZONE_ID", ""), // optional: skip zone name lookup
 			Domain:  strOr(prefix+"DOMAIN", ""),
 			IPv4:    boolVal(prefix+"IPV4", true),
 			IPv6:    boolVal(prefix+"IPV6", false),
@@ -249,8 +251,8 @@ func buildConfig(kv map[string]string) (*Config, error) {
 			if e.API == "" {
 				errs = append(errs, fmt.Sprintf("%sAPI: required when enabled", prefix))
 			}
-			if e.Zone == "" {
-				errs = append(errs, fmt.Sprintf("%sZONE: required when enabled", prefix))
+			if e.Zone == "" && e.ZoneID == "" {
+				errs = append(errs, fmt.Sprintf("%sZONE or %sZONE_ID: at least one required when enabled", prefix, prefix))
 			}
 			if e.Domain == "" {
 				errs = append(errs, fmt.Sprintf("%sDOMAIN: required when enabled", prefix))

--- a/internal/ddns/cloudflare.go
+++ b/internal/ddns/cloudflare.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -13,6 +14,7 @@ import (
 type CloudflareEntry struct {
 	API    string // API token with DNS:Edit permission
 	Zone   string // zone name (e.g. "example.com")
+	ZoneID string // zone ID (optional; skips zone-name lookup when set)
 	Domain string // FQDN of the record (e.g. "home.example.com")
 }
 
@@ -24,11 +26,15 @@ func UpdateCloudflare(entry CloudflareEntry, ip, recType, zonesURL string) Provi
 
 	client := &http.Client{Timeout: 15 * time.Second}
 
-	// 1. Resolve zone name → zone ID
-	zoneID, err := cfResolveZone(client, entry, zonesURL)
-	if err != nil {
-		pr.Err = fmt.Errorf("zone lookup: %w", err)
-		return pr
+	// 1. Resolve zone name → zone ID (skip when ZoneID is already known)
+	zoneID := entry.ZoneID
+	if zoneID == "" {
+		var err error
+		zoneID, err = cfResolveZone(client, entry, zonesURL)
+		if err != nil {
+			pr.Err = fmt.Errorf("zone lookup: %w", err)
+			return pr
+		}
 	}
 
 	// 2. Find the existing DNS record ID
@@ -60,27 +66,20 @@ func UpdateCloudflare(entry CloudflareEntry, ip, recType, zonesURL string) Provi
 	}
 	defer resp.Body.Close()
 
-	var result struct {
-		Success bool `json:"success"`
-		Errors  []struct {
-			Message string `json:"message"`
-		} `json:"errors"`
-	}
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&result); err != nil {
+	var result cfResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 65536)).Decode(&result); err != nil {
 		pr.Err = fmt.Errorf("decode response: %w", err)
 		return pr
 	}
 	if !result.Success {
-		msgs := make([]string, len(result.Errors))
-		for i, e := range result.Errors {
-			msgs[i] = e.Message
-		}
-		pr.Err = fmt.Errorf("cloudflare API error: %v", msgs)
+		pr.Err = fmt.Errorf("cloudflare API error: %s", result.errorString())
 	}
 	return pr
 }
 
 // cfResolveZone returns the zone ID for the given zone name.
+// This requires the API token to have Zone:Read permission.
+// If your token only has DNS:Edit, set CF_x_ZONE_ID in user.conf instead.
 func cfResolveZone(client *http.Client, entry CloudflareEntry, zonesURL string) (string, error) {
 	url := fmt.Sprintf("%s?name=%s", zonesURL, entry.Zone)
 	req, _ := http.NewRequest(http.MethodGet, url, nil)
@@ -93,15 +92,19 @@ func cfResolveZone(client *http.Client, entry CloudflareEntry, zonesURL string) 
 	defer resp.Body.Close()
 
 	var result struct {
+		cfResponse
 		Result []struct {
 			ID string `json:"id"`
 		} `json:"result"`
 	}
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&result); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 65536)).Decode(&result); err != nil {
 		return "", err
 	}
+	if !result.Success {
+		return "", fmt.Errorf("zones API error (token may lack Zone:Read permission): %s", result.errorString())
+	}
 	if len(result.Result) == 0 {
-		return "", fmt.Errorf("zone %q not found", entry.Zone)
+		return "", fmt.Errorf("zone %q not found — check zone name or set CF_x_ZONE_ID in user.conf", entry.Zone)
 	}
 	return result.Result[0].ID, nil
 }
@@ -119,15 +122,39 @@ func cfFindRecord(client *http.Client, entry CloudflareEntry, zoneID, recType, z
 	defer resp.Body.Close()
 
 	var result struct {
+		cfResponse
 		Result []struct {
 			ID string `json:"id"`
 		} `json:"result"`
 	}
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&result); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 65536)).Decode(&result); err != nil {
 		return "", err
+	}
+	if !result.Success {
+		return "", fmt.Errorf("dns_records API error: %s", result.errorString())
 	}
 	if len(result.Result) == 0 {
 		return "", fmt.Errorf("no %s record found for %s in zone %s", recType, entry.Domain, entry.Zone)
 	}
 	return result.Result[0].ID, nil
+}
+
+// cfResponse is the common envelope returned by all Cloudflare API calls.
+type cfResponse struct {
+	Success bool `json:"success"`
+	Errors  []struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+func (r cfResponse) errorString() string {
+	if len(r.Errors) == 0 {
+		return "(no error detail)"
+	}
+	msgs := make([]string, len(r.Errors))
+	for i, e := range r.Errors {
+		msgs[i] = fmt.Sprintf("[%d] %s", e.Code, e.Message)
+	}
+	return strings.Join(msgs, "; ")
 }

--- a/internal/ddns/ddns_test.go
+++ b/internal/ddns/ddns_test.go
@@ -86,13 +86,15 @@ func cfMockServer(t *testing.T, zoneID, recordID string) *httptest.Server {
 		// Zone lookup: GET /zones?name=...
 		case r.Method == http.MethodGet && strings.Contains(r.URL.RawQuery, "name="):
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"result": []map[string]string{{"id": zoneID}},
+				"success": true,
+				"result":  []map[string]string{{"id": zoneID}},
 			})
 
 		// Record lookup: GET /zones/{zoneID}/dns_records?type=...
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "dns_records"):
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"result": []map[string]string{{"id": recordID}},
+				"success": true,
+				"result":  []map[string]string{{"id": recordID}},
 			})
 
 		// Record update: PATCH /zones/{zoneID}/dns_records/{recordID}
@@ -126,8 +128,8 @@ func TestCloudflare_Success(t *testing.T) {
 func TestCloudflare_ZoneNotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		// Always return empty result list
-		json.NewEncoder(w).Encode(map[string]interface{}{"result": []interface{}{}})
+		// success=true but empty result list → zone not found
+		json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "result": []interface{}{}})
 	}))
 	defer srv.Close()
 
@@ -150,11 +152,12 @@ func TestCloudflare_RecordNotFound(t *testing.T) {
 		if callCount == 1 {
 			// Zone found
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"result": []map[string]string{{"id": "zone123"}},
+				"success": true,
+				"result":  []map[string]string{{"id": "zone123"}},
 			})
 		} else {
 			// No DNS records
-			json.NewEncoder(w).Encode(map[string]interface{}{"result": []interface{}{}})
+			json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "result": []interface{}{}})
 		}
 	}))
 	defer srv.Close()
@@ -178,16 +181,18 @@ func TestCloudflare_APIError(t *testing.T) {
 		switch callCount {
 		case 1: // zone lookup
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"result": []map[string]string{{"id": "zone123"}},
+				"success": true,
+				"result":  []map[string]string{{"id": "zone123"}},
 			})
 		case 2: // record lookup
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"result": []map[string]string{{"id": "rec456"}},
+				"success": true,
+				"result":  []map[string]string{{"id": "rec456"}},
 			})
 		default: // PATCH returns API error
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"success": false,
-				"errors":  []map[string]string{{"message": "invalid token"}},
+				"errors":  []map[string]interface{}{{"code": 9109, "message": "invalid token"}},
 			})
 		}
 	}))
@@ -216,11 +221,13 @@ func TestCloudflare_BearerTokenSent(t *testing.T) {
 		switch callCount {
 		case 1:
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"result": []map[string]string{{"id": "zone123"}},
+				"success": true,
+				"result":  []map[string]string{{"id": "zone123"}},
 			})
 		case 2:
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"result": []map[string]string{{"id": "rec456"}},
+				"success": true,
+				"result":  []map[string]string{{"id": "rec456"}},
 			})
 		default:
 			json.NewEncoder(w).Encode(map[string]interface{}{"success": true})
@@ -233,5 +240,74 @@ func TestCloudflare_BearerTokenSent(t *testing.T) {
 
 	if gotAuth != "Bearer my-secret-token" {
 		t.Errorf("Authorization header: got %q, want %q", gotAuth, "Bearer my-secret-token")
+	}
+}
+
+// TestCloudflare_ZoneID_SkipsLookup verifies that when ZoneID is set, the
+// zone name lookup API call is skipped entirely.  This supports API tokens
+// that only have DNS:Edit (no Zone:Read) permission.
+func TestCloudflare_ZoneID_SkipsLookup(t *testing.T) {
+	zoneLookupCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		// PATCH — record update
+		case r.Method == http.MethodPatch:
+			json.NewEncoder(w).Encode(map[string]interface{}{"success": true})
+
+		// Record lookup: GET .../dns_records?...
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "dns_records"):
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true,
+				"result":  []map[string]string{{"id": "rec999"}},
+			})
+
+		// Zone lookup: GET /zones?name=... (path does NOT contain dns_records)
+		case r.Method == http.MethodGet:
+			zoneLookupCalled = true
+			json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "result": []interface{}{}})
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	entry := CloudflareEntry{
+		API:    "dns-only-token",
+		ZoneID: "direct-zone-id", // provided directly — no lookup needed
+		Domain: "home.example.com",
+	}
+	result := UpdateCloudflare(entry, "1.2.3.4", "A", srv.URL)
+
+	if result.Err != nil {
+		t.Fatalf("unexpected error: %v", result.Err)
+	}
+	if zoneLookupCalled {
+		t.Error("zone lookup API should NOT have been called when ZoneID is set")
+	}
+}
+
+// TestCloudflare_ZoneNotFound_WithAPIError verifies that a proper error is
+// returned when the Cloudflare API reports success=false on zone lookup.
+func TestCloudflare_ZoneNotFound_WithAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"errors":  []map[string]interface{}{{"code": 9109, "message": "Invalid access token"}},
+			"result":  []interface{}{},
+		})
+	}))
+	defer srv.Close()
+
+	entry := CloudflareEntry{API: "bad-token", Zone: "example.com", Domain: "home.example.com"}
+	result := UpdateCloudflare(entry, "1.2.3.4", "A", srv.URL)
+
+	if result.Err == nil {
+		t.Fatal("expected error when API returns success=false")
+	}
+	if !strings.Contains(result.Err.Error(), "Invalid access token") {
+		t.Errorf("error should contain API message, got: %v", result.Err)
 	}
 }

--- a/internal/mode/update.go
+++ b/internal/mode/update.go
@@ -149,6 +149,7 @@ func Update(cfg *config.Config) error {
 		cfEntry := ddns.CloudflareEntry{
 			API:    cf.API,
 			Zone:   cf.Zone,
+			ZoneID: cf.ZoneID,
 			Domain: cf.Domain,
 		}
 		if wantV4 && cf.IPv4 && fetched.IPv4 != "" {


### PR DESCRIPTION
## 概要

Cloudflare の zone-scoped API トークン（DNS:Edit のみ）では `GET /zones?name=...` が空を返し「zone not found」エラーになっていた問題を修正。

## 変更内容

### CF_x_ZONE_ID の追加

`user.conf` に `CF_0_ZONE_ID=<ゾーンID>` を設定するとゾーン名ルックアップをスキップするようになった。

Zone ID の確認方法: Cloudflare ダッシュボード → 対象ドメイン → 概要 → 右サイドバーの「ゾーン ID」

```
# user.conf の例
CF_0_ENABLED=on
CF_0_API=<APIトークン>
CF_0_ZONE=smgjp.com          # 引き続き指定可
CF_0_ZONE_ID=<ゾーンID>       # これを追加するとゾーン名ルックアップをスキップ
CF_0_DOMAIN=test.smgjp.com
```

### エラーメッセージの改善

ゾーンルックアップ失敗時に Cloudflare API の実際のエラーコード・メッセージを表示するようになった。

## テスト追加

- TestCloudflare_ZoneID_SkipsLookup
- TestCloudflare_ZoneNotFound_WithAPIError

Closes #19