### PR TITLE
fix(update): DDNS_TIME keepalive — update even without IP change

### DIFF
--- a/internal/mode/update.go
+++ b/internal/mode/update.go
@@ -23,6 +23,13 @@ var (
 
 // Update is the main DDNS update mode.
 // Equivalent to `dipper update`.
+//
+// Logic:
+//   - IP is fetched on every invocation.
+//   - If IP has changed → DDNS is updated immediately (bypass DDNS_TIME gate).
+//   - If DDNS_TIME has elapsed → periodic keepalive update regardless of IP change.
+//     This ensures DDNS records are restored even if someone resets them externally.
+//   - Otherwise → skip silently.
 func Update(cfg *config.Config) error {
 	st, err := state.New(cfg.StateDir)
 	if err != nil {
@@ -81,27 +88,23 @@ func Update(cfg *config.Config) error {
 		}
 	}
 
-	// UPDATE_TIME: force re-sync even when IP is unchanged (catches external
-	// DDNS edits).  ipChanged bypasses this gate so IP changes are acted on
-	// immediately regardless of how recently the last sync ran.
-	updateGate := timegate.New(cfg.StateDir, "update", time.Duration(cfg.UpdateTime)*time.Minute)
-	forceSync := updateGate.ShouldRun()
+	// --- DDNS_TIME gate ---
+	// Controls the periodic keepalive update interval.
+	// When DDNS_TIME has elapsed, DDNS is updated regardless of IP change
+	// to restore any externally reset records.
+	// When IP has changed, the gate is bypassed for an immediate update.
+	ddnsGate := timegate.New(cfg.StateDir, "ddns", time.Duration(cfg.DDNSTime)*time.Minute)
+	ddnsReady := ddnsGate.ShouldRun()
 
-	if !ipChanged && !forceSync {
+	if !ipChanged && !ddnsReady {
 		fmt.Fprintln(os.Stderr, "dipper_ai update: IP unchanged, skipping DDNS")
 		return nil
 	}
-	if !ipChanged && forceSync {
-		fmt.Fprintln(os.Stderr, "dipper_ai update: forcing periodic re-sync")
-	}
 
-	// --- DDNS time gate: DDNS_TIME ---
-	// Bypassed when IP has changed (act immediately) or when force-sync is set.
-	// Only applies when IP is unchanged and no force-sync requested.
-	ddnsGate := timegate.New(cfg.StateDir, "ddns", time.Duration(cfg.DDNSTime)*time.Minute)
-	if !ipChanged && !forceSync && !ddnsGate.ShouldRun() {
-		fmt.Fprintln(os.Stderr, "dipper_ai update: DDNS gate active, skipping")
-		return nil
+	if ipChanged {
+		fmt.Fprintln(os.Stderr, "dipper_ai update: IP changed — updating DDNS")
+	} else {
+		fmt.Fprintln(os.Stderr, "dipper_ai update: DDNS keepalive")
 	}
 
 	var updateErr error
@@ -180,9 +183,6 @@ func Update(cfg *config.Config) error {
 		}
 	}
 
-	if forceSync {
-		_ = updateGate.Touch()
-	}
 	_ = ddnsGate.Touch()
 	return updateErr
 }

--- a/internal/mode/update_test.go
+++ b/internal/mode/update_test.go
@@ -112,9 +112,7 @@ func TestUpdate_IPChanged(t *testing.T) {
 		t.Fatalf("first run: %v", err)
 	}
 
-	// Reset update gate so second run is allowed
-	_ = os.Remove(cfg.StateDir + "/gate_update")
-	_ = os.Remove(cfg.StateDir + "/gate_ddns")
+	// IP change bypasses the DDNS gate — no need to remove any gate files.
 
 	// Second run with different IP
 	overrideFetch(t, fakeFetch("5.6.7.8", ""))
@@ -177,16 +175,17 @@ func TestUpdate_IPv6FetchFail_IPv4Proceeds(t *testing.T) {
 	}
 }
 
-// TestUpdate_ForceSync verifies that UPDATE_TIME triggers a DDNS re-sync even
-// when the IP has not changed (catches external DDNS edits / drift).
-func TestUpdate_ForceSync(t *testing.T) {
+// TestUpdate_Keepalive verifies that when DDNS_TIME elapses, DDNS is updated
+// even when the IP has not changed.  This is the "keepalive" behaviour that
+// restores externally reset DDNS records.
+func TestUpdate_Keepalive(t *testing.T) {
 	cfg := baseCfg(t)
 	cfg.MyDNS = []config.MyDNSEntry{{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true}}
 
 	overrideFetch(t, fakeFetch("1.2.3.4", ""))
 	calls := captureMyDNSCalls(t)
 
-	// First run — IP written to cache, DDNS called.
+	// First run — IP written to cache, DDNS called, gate_ddns touched.
 	if err := Update(cfg); err != nil {
 		t.Fatalf("first run: %v", err)
 	}
@@ -195,7 +194,7 @@ func TestUpdate_ForceSync(t *testing.T) {
 		t.Fatal("expected DDNS call on first run")
 	}
 
-	// Second run — same IP, gate_update still active → skip.
+	// Second run — same IP, gate_ddns still active → skip.
 	if err := Update(cfg); err != nil {
 		t.Fatalf("second run: %v", err)
 	}
@@ -203,15 +202,15 @@ func TestUpdate_ForceSync(t *testing.T) {
 		t.Errorf("expected no DDNS call when IP unchanged and gate active")
 	}
 
-	// Remove only the update gate to simulate UPDATE_TIME elapsed.
-	_ = os.Remove(cfg.StateDir + "/gate_update")
+	// Remove gate_ddns to simulate DDNS_TIME elapsed.
+	_ = os.Remove(cfg.StateDir + "/gate_ddns")
 
-	// Third run — same IP, but force-sync gate elapsed → DDNS must be called.
+	// Third run — same IP, but DDNS_TIME elapsed → keepalive → DDNS must fire.
 	if err := Update(cfg); err != nil {
-		t.Fatalf("force-sync run: %v", err)
+		t.Fatalf("keepalive run: %v", err)
 	}
 	if len(*calls) <= after1 {
-		t.Errorf("expected DDNS call on force-sync run (IP unchanged but UPDATE_TIME elapsed)")
+		t.Errorf("expected keepalive DDNS call when DDNS_TIME elapsed (IP unchanged)")
 	}
 }
 


### PR DESCRIPTION
## 概要

DDNS サーバーを手動で 0.0.0.0 にリセットしても、ローカルキャッシュが正しい IP を保持している限り update がスキップし続けるバグを修正。

## 新しいロジック



UPDATE_TIME / forceSync ゲートを廃止し DDNS_TIME に一本化。

Closes #25