### PR TITLE
feat: IP更新時のメール通知 (EMAIL_CHK_DDNS / EMAIL_UP_DDNS)

### DIFF
--- a/internal/mode/update.go
+++ b/internal/mode/update.go
@@ -4,6 +4,7 @@ package mode
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/Liplus-Project/dipper_ai/internal/config"
@@ -108,6 +109,7 @@ func Update(cfg *config.Config) error {
 	}
 
 	var updateErr error
+	var successLines []string // successful provider lines for mail notification
 
 	// --- MyDNS per-entry updates ---
 	for i, entry := range cfg.MyDNS {
@@ -127,6 +129,7 @@ func Update(cfg *config.Config) error {
 			} else {
 				_ = st.WriteDDNSResult(key, "ok")
 				fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv4: ok\n", i, entry.Domain)
+				successLines = append(successLines, fmt.Sprintf("  mydns[%d] %s ipv4: ok", i, entry.Domain))
 			}
 		}
 		if wantV6 && entry.IPv6 && fetched.IPv6 != "" {
@@ -140,6 +143,7 @@ func Update(cfg *config.Config) error {
 			} else {
 				_ = st.WriteDDNSResult(key, "ok")
 				fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv6: ok\n", i, entry.Domain)
+				successLines = append(successLines, fmt.Sprintf("  mydns[%d] %s ipv6: ok", i, entry.Domain))
 			}
 		}
 	}
@@ -166,6 +170,7 @@ func Update(cfg *config.Config) error {
 			} else {
 				_ = st.WriteDDNSResult(key, "ok")
 				fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s A: ok\n", i, cf.Domain)
+				successLines = append(successLines, fmt.Sprintf("  cf[%d] %s A: ok", i, cf.Domain))
 			}
 		}
 		if wantV6 && cf.IPv6 && fetched.IPv6 != "" {
@@ -179,10 +184,49 @@ func Update(cfg *config.Config) error {
 			} else {
 				_ = st.WriteDDNSResult(key, "ok")
 				fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s AAAA: ok\n", i, cf.Domain)
+				successLines = append(successLines, fmt.Sprintf("  cf[%d] %s AAAA: ok", i, cf.Domain))
 			}
 		}
 	}
 
 	_ = ddnsGate.Touch()
+
+	// --- Email notification ---
+	// Send only when the relevant flag is set and at least one provider succeeded.
+	wantMail := cfg.EmailAddr != "" && len(successLines) > 0 &&
+		((ipChanged && cfg.EmailChkDDNS) || (!ipChanged && cfg.EmailUpDDNS))
+	if wantMail {
+		if mailErr := sendUpdateNotification(cfg, fetched, ipChanged, successLines); mailErr != nil {
+			_ = st.AppendError(fmt.Sprintf("update_mail_failed: %v", mailErr))
+			fmt.Fprintf(os.Stderr, "dipper_ai update: mail notification failed: %v\n", mailErr)
+			// Mail failure is non-fatal; do not override updateErr.
+		}
+	}
+
 	return updateErr
+}
+
+// sendUpdateNotification composes and sends an IP-update notification email.
+func sendUpdateNotification(cfg *config.Config, fetched *ip.Result, ipChanged bool, successLines []string) error {
+	reason := "DDNS keepalive"
+	if ipChanged {
+		reason = "IP changed"
+	}
+
+	var ipLines []string
+	if fetched.IPv4 != "" {
+		ipLines = append(ipLines, "IPv4: "+fetched.IPv4)
+	}
+	if fetched.IPv6 != "" {
+		ipLines = append(ipLines, "IPv6: "+fetched.IPv6)
+	}
+
+	subject := "dipper_ai: IP updated"
+	body := fmt.Sprintf("%s\n\nReason: %s\n\nUpdated providers:\n%s\n",
+		strings.Join(ipLines, "\n"),
+		reason,
+		strings.Join(successLines, "\n"),
+	)
+
+	return sendMailFn(cfg.EmailAddr, subject, body)
 }

--- a/internal/mode/update_test.go
+++ b/internal/mode/update_test.go
@@ -3,6 +3,7 @@ package mode
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/Liplus-Project/dipper_ai/internal/config"
@@ -269,5 +270,129 @@ func TestUpdate_PerEntryIPv4IPv6(t *testing.T) {
 		if c == "ipv6:a.example.com" {
 			t.Error("IPv6 should be skipped for a.example.com (IPv6=false)")
 		}
+	}
+}
+
+// captureMailCalls replaces sendMailFn for the duration of a test.
+// Returns a pointer to a slice of recorded "to|subject|body" strings.
+func captureMailCalls(t *testing.T) *[]string {
+	t.Helper()
+	sent := &[]string{}
+	orig := sendMailFn
+	sendMailFn = func(to, subject, body string) error {
+		*sent = append(*sent, to+"|"+subject+"|"+body)
+		return nil
+	}
+	t.Cleanup(func() { sendMailFn = orig })
+	return sent
+}
+
+// TestUpdate_Mail_IPChanged verifies that when EMAIL_CHK_DDNS is on and the IP
+// changes, a mail notification is sent containing the new IP and provider list.
+func TestUpdate_Mail_IPChanged(t *testing.T) {
+	cfg := baseCfg(t)
+	cfg.EmailAddr = "test@example.com"
+	cfg.EmailChkDDNS = true
+	cfg.MyDNS = []config.MyDNSEntry{{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true}}
+
+	overrideFetch(t, fakeFetch("1.2.3.4", ""))
+	captureMyDNSCalls(t)
+	sent := captureMailCalls(t)
+
+	if err := Update(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(*sent) == 0 {
+		t.Fatal("expected mail to be sent on IP change")
+	}
+	mail := (*sent)[0]
+	if !strings.Contains(mail, "1.2.3.4") {
+		t.Errorf("mail body should contain new IPv4, got: %s", mail)
+	}
+	if !strings.Contains(mail, "IP changed") {
+		t.Errorf("mail body should contain reason 'IP changed', got: %s", mail)
+	}
+	if !strings.Contains(mail, "home.example.com") {
+		t.Errorf("mail body should contain domain, got: %s", mail)
+	}
+}
+
+// TestUpdate_Mail_Keepalive verifies that EMAIL_UP_DDNS triggers mail on
+// keepalive updates (IP unchanged, DDNS_TIME elapsed), not on IP-change runs.
+func TestUpdate_Mail_Keepalive(t *testing.T) {
+	cfg := baseCfg(t)
+	cfg.EmailAddr = "test@example.com"
+	cfg.EmailUpDDNS = true // notify on keepalive only
+	cfg.EmailChkDDNS = false
+	cfg.MyDNS = []config.MyDNSEntry{{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true}}
+
+	overrideFetch(t, fakeFetch("1.2.3.4", ""))
+	captureMyDNSCalls(t)
+	sent := captureMailCalls(t)
+
+	// First run: IP changed (0.0.0.0 → 1.2.3.4) → EMAIL_CHK_DDNS=false → no mail.
+	if err := Update(cfg); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if len(*sent) != 0 {
+		t.Errorf("no mail expected on IP-change run when EMAIL_CHK_DDNS=false, got %d", len(*sent))
+	}
+
+	// Simulate DDNS_TIME elapsed.
+	_ = os.Remove(cfg.StateDir + "/gate_ddns")
+
+	// Second run: same IP, keepalive → EMAIL_UP_DDNS=true → mail expected.
+	if err := Update(cfg); err != nil {
+		t.Fatalf("keepalive run: %v", err)
+	}
+	if len(*sent) == 0 {
+		t.Error("expected mail on keepalive run when EMAIL_UP_DDNS=true")
+	} else {
+		mail := (*sent)[0]
+		if !strings.Contains(mail, "DDNS keepalive") {
+			t.Errorf("mail body should contain reason 'DDNS keepalive', got: %s", mail)
+		}
+	}
+}
+
+// TestUpdate_Mail_BothOff verifies that no mail is sent when both
+// EMAIL_CHK_DDNS and EMAIL_UP_DDNS are false.
+func TestUpdate_Mail_BothOff(t *testing.T) {
+	cfg := baseCfg(t)
+	cfg.EmailAddr = "test@example.com"
+	cfg.EmailChkDDNS = false
+	cfg.EmailUpDDNS = false
+	cfg.MyDNS = []config.MyDNSEntry{{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true}}
+
+	overrideFetch(t, fakeFetch("1.2.3.4", ""))
+	captureMyDNSCalls(t)
+	sent := captureMailCalls(t)
+
+	if err := Update(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(*sent) != 0 {
+		t.Errorf("expected no mail when both flags off, got %d", len(*sent))
+	}
+}
+
+// TestUpdate_Mail_FailureIsNonFatal verifies that a mail-send failure does not
+// cause Update() to return an error (DDNS update itself succeeded).
+func TestUpdate_Mail_FailureIsNonFatal(t *testing.T) {
+	cfg := baseCfg(t)
+	cfg.EmailAddr = "test@example.com"
+	cfg.EmailChkDDNS = true
+	cfg.MyDNS = []config.MyDNSEntry{{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true}}
+
+	overrideFetch(t, fakeFetch("1.2.3.4", ""))
+	captureMyDNSCalls(t)
+
+	orig := sendMailFn
+	sendMailFn = func(_, _, _ string) error { return errors.New("sendmail: connection refused") }
+	t.Cleanup(func() { sendMailFn = orig })
+
+	if err := Update(cfg); err != nil {
+		t.Errorf("mail failure should be non-fatal, got error: %v", err)
 	}
 }


### PR DESCRIPTION
## 概要

Closes #28

DDNS 更新が実行された際、設定に応じたメール通知を送信する。

## 変更内容

**`internal/mode/update.go`**
- 各プロバイダの更新成功行を `successLines []string` に収集
- 全 DDNS 更新完了後、`sendUpdateNotification()` を呼び出し
- `wantMail` 判定: `(ipChanged && EmailChkDDNS) || (!ipChanged && EmailUpDDNS)`
- メール送信失敗は non-fatal（stderr + state error に記録）

**`internal/mode/update_test.go`**
- `captureMailCalls()` ヘルパー追加
- `TestUpdate_Mail_IPChanged` — IP変化時に通知が届くことを確認
- `TestUpdate_Mail_Keepalive` — キープアライブ時のみ通知（EMAIL_CHK_DDNS=false）
- `TestUpdate_Mail_BothOff` — 両フラグ off ならメール送信なし
- `TestUpdate_Mail_FailureIsNonFatal` — メール失敗でも Update() は成功扱い

## テスト

```
ok  github.com/Liplus-Project/dipper_ai/internal/mode  (all PASS)
ok  github.com/Liplus-Project/dipper_ai/...            (all PASS)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)