### PR TITLE
fix: DDNS_TIME=0 をデフォルトに — IP変化時のみ更新

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 
 	// Time gates (minutes)
 	// UpdateTime:  minimum 3
-	// DDNSTime:    minimum 1
+	// DDNSTime:    0 = keepalive disabled (IP-change only); else minimum 1
 	// IPCacheTime: 0 = disabled, else minimum 15
 	// ErrChkTime:  0 = disabled, else minimum 1
 	UpdateTime  int
@@ -203,7 +203,7 @@ func buildConfig(kv map[string]string) (*Config, error) {
 
 	// --- Time gates ---
 	c.UpdateTime = intMin("UPDATE_TIME", 1440, 3)
-	c.DDNSTime = intMin("DDNS_TIME", 1, 1)
+	c.DDNSTime = intGate("DDNS_TIME", 0, 1) // 0 = keepalive disabled (default); N = keepalive every N minutes
 	c.IPCacheTime = intGate("IP_CACHE_TIME", 0, 15)
 	c.ErrChkTime = intGate("ERR_CHK_TIME", 0, 1)
 

--- a/internal/mode/update.go
+++ b/internal/mode/update.go
@@ -90,12 +90,15 @@ func Update(cfg *config.Config) error {
 	}
 
 	// --- DDNS_TIME gate ---
-	// Controls the periodic keepalive update interval.
-	// When DDNS_TIME has elapsed, DDNS is updated regardless of IP change
-	// to restore any externally reset records.
-	// When IP has changed, the gate is bypassed for an immediate update.
-	ddnsGate := timegate.New(cfg.StateDir, "ddns", time.Duration(cfg.DDNSTime)*time.Minute)
-	ddnsReady := ddnsGate.ShouldRun()
+	// DDNS_TIME=0 (default): keepalive disabled; update only on IP change.
+	// DDNS_TIME>0: periodic keepalive every N minutes regardless of IP change,
+	//              which is required by services like MyDNS that expire records.
+	var ddnsGate *timegate.Gate
+	ddnsReady := false
+	if cfg.DDNSTime > 0 {
+		ddnsGate = timegate.New(cfg.StateDir, "ddns", time.Duration(cfg.DDNSTime)*time.Minute)
+		ddnsReady = ddnsGate.ShouldRun()
+	}
 
 	if !ipChanged && !ddnsReady {
 		fmt.Fprintln(os.Stderr, "dipper_ai update: IP unchanged, skipping DDNS")
@@ -189,7 +192,9 @@ func Update(cfg *config.Config) error {
 		}
 	}
 
-	_ = ddnsGate.Touch()
+	if ddnsGate != nil {
+		_ = ddnsGate.Touch()
+	}
 
 	// --- Email notification ---
 	// Send only when the relevant flag is set and at least one provider succeeded.

--- a/internal/mode/update_test.go
+++ b/internal/mode/update_test.go
@@ -66,6 +66,7 @@ func captureMyDNSCalls(t *testing.T) *[]string {
 }
 
 // baseCfg builds a minimal Config for update tests.
+// DDNSTime defaults to 0 (keepalive disabled) — IP-change only.
 func baseCfg(t *testing.T) *config.Config {
 	t.Helper()
 	return &config.Config{
@@ -73,7 +74,7 @@ func baseCfg(t *testing.T) *config.Config {
 		IPv4:       true,
 		IPv4DDNS:   true,
 		UpdateTime: 1,
-		DDNSTime:   1,
+		DDNSTime:   0, // keepalive disabled by default
 	}
 }
 
@@ -181,6 +182,7 @@ func TestUpdate_IPv6FetchFail_IPv4Proceeds(t *testing.T) {
 // restores externally reset DDNS records.
 func TestUpdate_Keepalive(t *testing.T) {
 	cfg := baseCfg(t)
+	cfg.DDNSTime = 1 // enable keepalive for this test
 	cfg.MyDNS = []config.MyDNSEntry{{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true}}
 
 	overrideFetch(t, fakeFetch("1.2.3.4", ""))
@@ -322,6 +324,7 @@ func TestUpdate_Mail_IPChanged(t *testing.T) {
 // keepalive updates (IP unchanged, DDNS_TIME elapsed), not on IP-change runs.
 func TestUpdate_Mail_Keepalive(t *testing.T) {
 	cfg := baseCfg(t)
+	cfg.DDNSTime = 1 // enable keepalive so the second run triggers it
 	cfg.EmailAddr = "test@example.com"
 	cfg.EmailUpDDNS = true // notify on keepalive only
 	cfg.EmailChkDDNS = false


### PR DESCRIPTION
## 概要

Closes #30

IP が変化していないのに DDNS 更新が走るのは DDNS クライアントとして誤った動作。
`DDNS_TIME` のデフォルトを `0`（keepalive無効）に変更し、IP変化時のみ更新する動作をデフォルトにする。

## 動作変更

| 設定 | 動作 |
|---|---|
| `DDNS_TIME` 未設定（= 0） | IP変化時のみ更新 ← **新しいデフォルト** |
| `DDNS_TIME=60` | IP変化 + 60分ごとのキープアライブ |

## 変更ファイル

- **`internal/config/config.go`** — `DDNS_TIME` を `intMin` → `intGate` に変更、デフォルトを `0` に
- **`internal/mode/update.go`** — `DDNSTime=0` のとき `ddnsGate` を生成しない（nil チェック追加）
- **`internal/mode/update_test.go`** — `baseCfg` の `DDNSTime` を `0` に。keepalive テストは明示的に `DDNSTime=1` を設定

## テスト

```
ok  github.com/Liplus-Project/dipper_ai/...  (all PASS)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)