### PR TITLE
refactor: per-domain IP cache + MyDNS-only keepalive (issue #32)

### DIFF
--- a/internal/mode/check.go
+++ b/internal/mode/check.go
@@ -117,19 +117,38 @@ func Check(cfg *config.Config) error {
 		return nil
 	}
 
-	// Mismatch detected: reset IP cache so Update() sees a change and pushes
-	// the correct IP to all DDNS providers immediately.
+	// Mismatch detected: reset per-domain caches for mismatched entries so
+	// the next Update() call sees a cache miss and re-sends to those providers.
+	// Also delete gate_ddns so DDNS_TIME rate-limit does not delay the fix.
 	fmt.Fprintln(os.Stderr, "dipper_ai check: mismatch detected — forcing DDNS update")
 	st, err := state.New(cfg.StateDir)
 	if err != nil {
 		return err
 	}
-	if wantV4 && fetched.IPv4 != "" {
-		_ = st.WriteIP("ipv4", "0.0.0.0")
+	for i, m := range cfg.MyDNS {
+		entryKey := fmt.Sprintf("mydns_%d", i)
+		if wantV4 && m.IPv4 && fetched.IPv4 != "" {
+			_ = st.ResetDomainCache(entryKey, "ipv4")
+		}
+		if wantV6 && m.IPv6 && fetched.IPv6 != "" {
+			_ = st.ResetDomainCache(entryKey, "ipv6")
+		}
 	}
-	if wantV6 && fetched.IPv6 != "" {
-		_ = st.WriteIP("ipv6", "::")
+	for i, cf := range cfg.Cloudflare {
+		if !cf.Enabled {
+			continue
+		}
+		entryKey := fmt.Sprintf("cf_%d", i)
+		if wantV4 && cf.IPv4 && fetched.IPv4 != "" {
+			_ = st.ResetDomainCache(entryKey, "A")
+		}
+		if wantV6 && cf.IPv6 && fetched.IPv6 != "" {
+			_ = st.ResetDomainCache(entryKey, "AAAA")
+		}
 	}
+
+	// Remove DDNS_TIME gate so Update() is not rate-limited on this forced run.
+	_ = os.Remove(cfg.StateDir + "/gate_ddns")
 
 	updateErr := Update(cfg)
 	_ = checkGate.Touch()

--- a/internal/mode/check_test.go
+++ b/internal/mode/check_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/Liplus-Project/dipper_ai/internal/config"
 	"github.com/Liplus-Project/dipper_ai/internal/ddns"
@@ -203,50 +204,62 @@ func TestCheck_Gate_SkipsWhenRecent(t *testing.T) {
 	}
 }
 
-// TestUpdate_DDNSGate_BypassedOnIPChange verifies that a real IP change
-// bypasses the DDNS_TIME gate even when the gate is still active.
-func TestUpdate_DDNSGate_BypassedOnIPChange(t *testing.T) {
+// TestUpdate_PerDomain_OnlyChangedEntry verifies that only the entry whose
+// per-domain cache differs from the current IP is updated; unchanged entries
+// are skipped even when the timer fires.
+func TestUpdate_PerDomain_OnlyChangedEntry(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{
 		StateDir:     dir,
 		IPv4:         true,
 		IPv4DDNS:     true,
 		UpdateTime:   1440,
-		DDNSTime:     1440, // very long — gate stays active
 		MyDNSIPv4URL: "http://fake.invalid/login.html",
 		MyDNS: []config.MyDNSEntry{
-			{ID: "u", Pass: "p", Domain: "home.example.com", IPv4: true},
+			{ID: "u0", Pass: "p0", Domain: "entry0.example.com", IPv4: true},
+			{ID: "u1", Pass: "p1", Domain: "entry1.example.com", IPv4: true},
 		},
 	}
 
-	// Pre-cache an old IP so the first update() run touches the ddnsGate.
+	// Pre-seed entry0 cache with current IP (already up-to-date).
+	// entry1 cache is empty (0.0.0.0) → needs update.
 	st, _ := state.New(dir)
-	_ = st.WriteIP("ipv4", "1.1.1.1")
+	_ = st.WriteDomainCache("mydns_0", "ipv4", "1.2.3.4")
+	// mydns_1 left at default (0.0.0.0)
+
+	// Pre-touch gate_update so forceSync does not fire on this run.
+	gateFile := dir + "/gate_update"
+	_ = os.WriteFile(gateFile, []byte(time.Now().Format(time.RFC3339)), 0644)
 
 	origFetch := ipFetch
-	ipFetch = fakeFetchIP("1.1.1.1") // no change yet
+	ipFetch = fakeFetchIP("1.2.3.4")
 	t.Cleanup(func() { ipFetch = origFetch })
 
+	updated := &[]string{}
 	origMyDNS := mydnsUpdateIPv4
-	callCount := 0
 	mydnsUpdateIPv4 = func(e ddns.MyDNSEntry, u string) ddns.ProviderResult {
-		callCount++
+		*updated = append(*updated, e.Domain)
 		return ddns.ProviderResult{}
 	}
 	t.Cleanup(func() { mydnsUpdateIPv4 = origMyDNS })
 
-	// First update: IP unchanged → gate should block (DDNSTime=1440 → gate active after touch)
-	// Actually on first run gate_ddns doesn't exist yet → ShouldRun=true → update fires
-	_ = Update(cfg)
-	after1 := callCount
+	if err := Update(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-	// Now simulate IP change — gate_ddns is now active (just touched).
-	ipFetch = fakeFetchIP("9.9.9.9") // new IP
-
-	_ = Update(cfg)
-	after2 := callCount
-
-	if after2 <= after1 {
-		t.Errorf("IP change should bypass DDNS gate; callCount before=%d after=%d", after1, after2)
+	// Only entry1 should have been updated.
+	for _, d := range *updated {
+		if d == "entry0.example.com" {
+			t.Error("entry0 should NOT be updated (cache already matches)")
+		}
+	}
+	found1 := false
+	for _, d := range *updated {
+		if d == "entry1.example.com" {
+			found1 = true
+		}
+	}
+	if !found1 {
+		t.Error("entry1 should have been updated (cache was 0.0.0.0)")
 	}
 }

--- a/internal/mode/update.go
+++ b/internal/mode/update.go
@@ -26,23 +26,38 @@ var (
 // Equivalent to `dipper update`.
 //
 // Logic:
-//   - IP is fetched on every invocation.
-//   - If IP has changed → DDNS is updated immediately (bypass DDNS_TIME gate).
-//   - If DDNS_TIME has elapsed → periodic keepalive update regardless of IP change.
-//     This ensures DDNS records are restored even if someone resets them externally.
-//   - Otherwise → skip silently.
+//   - Current external IP is fetched on every invocation.
+//   - Per-domain IP cache: each provider entry independently tracks the last
+//     IP it was sent. Only entries whose cached IP differs from the current
+//     IP are updated ("changed domains only").
+//   - MyDNS keepalive: when UPDATE_TIME has elapsed, all MyDNS entries are
+//     force-updated regardless of IP change. MyDNS registrations expire if
+//     not refreshed periodically.
+//   - Cloudflare: no keepalive — API records persist until explicitly changed.
+//   - DDNS_TIME: outer rate-limit gate. When set (>0), the entire check+update
+//     process runs at most once per DDNS_TIME minutes (except when bypassed by
+//     a caller such as check.go which deletes gate_ddns first).
 func Update(cfg *config.Config) error {
 	st, err := state.New(cfg.StateDir)
 	if err != nil {
 		return err
 	}
 
-	// --- Fetch IPs (always — IP must be checked on every run) ---
+	// --- DDNS_TIME outer gate (rate limiter) ---
+	// 0 = disabled (run every invocation); N = run at most every N minutes.
+	var ddnsGate *timegate.Gate
+	if cfg.DDNSTime > 0 {
+		ddnsGate = timegate.New(cfg.StateDir, "ddns", time.Duration(cfg.DDNSTime)*time.Minute)
+		if !ddnsGate.ShouldRun() {
+			return nil
+		}
+	}
+
+	// --- Fetch current external IP ---
 	wantV4 := cfg.IPv4 && cfg.IPv4DDNS
 	wantV6 := cfg.IPv6 && cfg.IPv6DDNS
 	fetched, _ := ipFetch(wantV4, wantV6)
 
-	// Log per-family fetch errors; IPv6 failure alone is non-fatal.
 	if wantV4 && fetched.ErrIPv4 != nil {
 		_ = st.AppendError(fmt.Sprintf("ip_fetch_error ipv4: %v", fetched.ErrIPv4))
 		fmt.Fprintf(os.Stderr, "dipper_ai update: IPv4 fetch failed: %v\n", fetched.ErrIPv4)
@@ -51,7 +66,6 @@ func Update(cfg *config.Config) error {
 		_ = st.AppendError(fmt.Sprintf("ip_fetch_error ipv6: %v", fetched.ErrIPv6))
 		fmt.Fprintf(os.Stderr, "dipper_ai update: IPv6 fetch failed: %v\n", fetched.ErrIPv6)
 	}
-	// Abort only when nothing usable was fetched at all.
 	if fetched.IPv4 == "" && fetched.IPv6 == "" && (wantV4 || wantV6) {
 		if fetched.ErrIPv4 != nil {
 			return fetched.ErrIPv4
@@ -66,145 +80,154 @@ func Update(cfg *config.Config) error {
 		fmt.Fprintf(os.Stderr, "dipper_ai update: IPv6=%s\n", fetched.IPv6)
 	}
 
-	// --- IP change detection ---
-	// Cache is initialised to 0.0.0.0 / :: so first run always triggers DDNS.
-	ipChanged := false
-
-	if fetched.IPv4 != "" {
-		cached, _ := st.ReadIP("ipv4")
-		if fetched.IPv4 != cached {
-			ipChanged = true
-			if err := st.WriteIP("ipv4", fetched.IPv4); err != nil {
-				return err
-			}
-		}
-	}
-	if fetched.IPv6 != "" {
-		cached, _ := st.ReadIP("ipv6")
-		if fetched.IPv6 != cached {
-			ipChanged = true
-			if err := st.WriteIP("ipv6", fetched.IPv6); err != nil {
-				return err
-			}
-		}
-	}
-
-	// --- DDNS_TIME gate ---
-	// DDNS_TIME=0 (default): keepalive disabled; update only on IP change.
-	// DDNS_TIME>0: periodic keepalive every N minutes regardless of IP change,
-	//              which is required by services like MyDNS that expire records.
-	var ddnsGate *timegate.Gate
-	ddnsReady := false
-	if cfg.DDNSTime > 0 {
-		ddnsGate = timegate.New(cfg.StateDir, "ddns", time.Duration(cfg.DDNSTime)*time.Minute)
-		ddnsReady = ddnsGate.ShouldRun()
-	}
-
-	if !ipChanged && !ddnsReady {
-		fmt.Fprintln(os.Stderr, "dipper_ai update: IP unchanged, skipping DDNS")
-		return nil
-	}
-
-	if ipChanged {
-		fmt.Fprintln(os.Stderr, "dipper_ai update: IP changed — updating DDNS")
-	} else {
-		fmt.Fprintln(os.Stderr, "dipper_ai update: DDNS keepalive")
-	}
+	// --- UPDATE_TIME gate: MyDNS keepalive ---
+	// When elapsed, all MyDNS entries are force-updated regardless of IP change.
+	// Cloudflare is excluded — its records persist without periodic refresh.
+	updateGate := timegate.New(cfg.StateDir, "update", time.Duration(cfg.UpdateTime)*time.Minute)
+	forceSync := updateGate.ShouldRun()
 
 	var updateErr error
-	var successLines []string // successful provider lines for mail notification
+	var successLines []string
+	anyUpdate := false
+	anyIPChange := false  // at least one domain updated due to IP change
+	anyKeepAlive := false // at least one MyDNS domain updated due to keepalive
 
 	// --- MyDNS per-entry updates ---
+	// Each entry is updated independently based on its own per-domain cache.
 	for i, entry := range cfg.MyDNS {
+		entryKey := fmt.Sprintf("mydns_%d", i)
 		dnsEntry := ddns.MyDNSEntry{
 			ID:     entry.ID,
 			Pass:   entry.Pass,
 			Domain: entry.Domain,
 		}
+
 		if wantV4 && entry.IPv4 && fetched.IPv4 != "" {
-			r := mydnsUpdateIPv4(dnsEntry, cfg.MyDNSIPv4URL)
-			key := fmt.Sprintf("mydns_%d_ipv4", i)
-			if r.Err != nil {
-				_ = st.WriteDDNSResult(key, "fail:"+r.Err.Error())
-				_ = st.AppendError(fmt.Sprintf("ddns_error mydns[%d] ipv4: %v", i, r.Err))
-				fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv4: FAIL: %v\n", i, entry.Domain, r.Err)
-				updateErr = r.Err
-			} else {
-				_ = st.WriteDDNSResult(key, "ok")
-				fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv4: ok\n", i, entry.Domain)
-				successLines = append(successLines, fmt.Sprintf("  mydns[%d] %s ipv4: ok", i, entry.Domain))
+			cached, _ := st.ReadDomainCache(entryKey, "ipv4")
+			ipDiffers := fetched.IPv4 != cached
+			if ipDiffers || forceSync {
+				r := mydnsUpdateIPv4(dnsEntry, cfg.MyDNSIPv4URL)
+				if r.Err != nil {
+					_ = st.WriteDDNSResult(entryKey+"_ipv4", "fail:"+r.Err.Error())
+					_ = st.AppendError(fmt.Sprintf("ddns_error mydns[%d] ipv4: %v", i, r.Err))
+					fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv4: FAIL: %v\n", i, entry.Domain, r.Err)
+					updateErr = r.Err
+				} else {
+					_ = st.WriteDomainCache(entryKey, "ipv4", fetched.IPv4)
+					_ = st.WriteDDNSResult(entryKey+"_ipv4", "ok")
+					fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv4: ok\n", i, entry.Domain)
+					successLines = append(successLines, fmt.Sprintf("  mydns[%d] %s ipv4: ok", i, entry.Domain))
+					anyUpdate = true
+					if ipDiffers {
+						anyIPChange = true
+					} else {
+						anyKeepAlive = true
+					}
+				}
 			}
 		}
+
 		if wantV6 && entry.IPv6 && fetched.IPv6 != "" {
-			r := mydnsUpdateIPv6(dnsEntry, cfg.MyDNSIPv6URL)
-			key := fmt.Sprintf("mydns_%d_ipv6", i)
-			if r.Err != nil {
-				_ = st.WriteDDNSResult(key, "fail:"+r.Err.Error())
-				_ = st.AppendError(fmt.Sprintf("ddns_error mydns[%d] ipv6: %v", i, r.Err))
-				fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv6: FAIL: %v\n", i, entry.Domain, r.Err)
-				updateErr = r.Err
-			} else {
-				_ = st.WriteDDNSResult(key, "ok")
-				fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv6: ok\n", i, entry.Domain)
-				successLines = append(successLines, fmt.Sprintf("  mydns[%d] %s ipv6: ok", i, entry.Domain))
+			cached, _ := st.ReadDomainCache(entryKey, "ipv6")
+			ipDiffers := fetched.IPv6 != cached
+			if ipDiffers || forceSync {
+				r := mydnsUpdateIPv6(dnsEntry, cfg.MyDNSIPv6URL)
+				if r.Err != nil {
+					_ = st.WriteDDNSResult(entryKey+"_ipv6", "fail:"+r.Err.Error())
+					_ = st.AppendError(fmt.Sprintf("ddns_error mydns[%d] ipv6: %v", i, r.Err))
+					fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv6: FAIL: %v\n", i, entry.Domain, r.Err)
+					updateErr = r.Err
+				} else {
+					_ = st.WriteDomainCache(entryKey, "ipv6", fetched.IPv6)
+					_ = st.WriteDDNSResult(entryKey+"_ipv6", "ok")
+					fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv6: ok\n", i, entry.Domain)
+					successLines = append(successLines, fmt.Sprintf("  mydns[%d] %s ipv6: ok", i, entry.Domain))
+					anyUpdate = true
+					if ipDiffers {
+						anyIPChange = true
+					} else {
+						anyKeepAlive = true
+					}
+				}
 			}
 		}
 	}
 
-	// --- Cloudflare per-entry updates ---
+	// --- Cloudflare per-entry updates (IP change only — no keepalive) ---
 	for i, cf := range cfg.Cloudflare {
 		if !cf.Enabled {
 			continue
 		}
+		entryKey := fmt.Sprintf("cf_%d", i)
 		cfEntry := ddns.CloudflareEntry{
 			API:    cf.API,
 			Zone:   cf.Zone,
 			ZoneID: cf.ZoneID,
 			Domain: cf.Domain,
 		}
+
 		if wantV4 && cf.IPv4 && fetched.IPv4 != "" {
-			r := cloudflareUpdate(cfEntry, fetched.IPv4, "A", cfg.CloudflareURL)
-			key := fmt.Sprintf("cf_%d_A", i)
-			if r.Err != nil {
-				_ = st.WriteDDNSResult(key, "fail:"+r.Err.Error())
-				_ = st.AppendError(fmt.Sprintf("ddns_error cloudflare[%d] A: %v", i, r.Err))
-				fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s A: FAIL: %v\n", i, cf.Domain, r.Err)
-				updateErr = r.Err
-			} else {
-				_ = st.WriteDDNSResult(key, "ok")
-				fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s A: ok\n", i, cf.Domain)
-				successLines = append(successLines, fmt.Sprintf("  cf[%d] %s A: ok", i, cf.Domain))
+			cached, _ := st.ReadDomainCache(entryKey, "A")
+			if fetched.IPv4 != cached {
+				r := cloudflareUpdate(cfEntry, fetched.IPv4, "A", cfg.CloudflareURL)
+				if r.Err != nil {
+					_ = st.WriteDDNSResult(entryKey+"_A", "fail:"+r.Err.Error())
+					_ = st.AppendError(fmt.Sprintf("ddns_error cloudflare[%d] A: %v", i, r.Err))
+					fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s A: FAIL: %v\n", i, cf.Domain, r.Err)
+					updateErr = r.Err
+				} else {
+					_ = st.WriteDomainCache(entryKey, "A", fetched.IPv4)
+					_ = st.WriteDDNSResult(entryKey+"_A", "ok")
+					fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s A: ok\n", i, cf.Domain)
+					successLines = append(successLines, fmt.Sprintf("  cf[%d] %s A: ok", i, cf.Domain))
+					anyUpdate = true
+					anyIPChange = true
+				}
 			}
 		}
+
 		if wantV6 && cf.IPv6 && fetched.IPv6 != "" {
-			r := cloudflareUpdate(cfEntry, fetched.IPv6, "AAAA", cfg.CloudflareURL)
-			key := fmt.Sprintf("cf_%d_AAAA", i)
-			if r.Err != nil {
-				_ = st.WriteDDNSResult(key, "fail:"+r.Err.Error())
-				_ = st.AppendError(fmt.Sprintf("ddns_error cloudflare[%d] AAAA: %v", i, r.Err))
-				fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s AAAA: FAIL: %v\n", i, cf.Domain, r.Err)
-				updateErr = r.Err
-			} else {
-				_ = st.WriteDDNSResult(key, "ok")
-				fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s AAAA: ok\n", i, cf.Domain)
-				successLines = append(successLines, fmt.Sprintf("  cf[%d] %s AAAA: ok", i, cf.Domain))
+			cached, _ := st.ReadDomainCache(entryKey, "AAAA")
+			if fetched.IPv6 != cached {
+				r := cloudflareUpdate(cfEntry, fetched.IPv6, "AAAA", cfg.CloudflareURL)
+				if r.Err != nil {
+					_ = st.WriteDDNSResult(entryKey+"_AAAA", "fail:"+r.Err.Error())
+					_ = st.AppendError(fmt.Sprintf("ddns_error cloudflare[%d] AAAA: %v", i, r.Err))
+					fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s AAAA: FAIL: %v\n", i, cf.Domain, r.Err)
+					updateErr = r.Err
+				} else {
+					_ = st.WriteDomainCache(entryKey, "AAAA", fetched.IPv6)
+					_ = st.WriteDDNSResult(entryKey+"_AAAA", "ok")
+					fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s AAAA: ok\n", i, cf.Domain)
+					successLines = append(successLines, fmt.Sprintf("  cf[%d] %s AAAA: ok", i, cf.Domain))
+					anyUpdate = true
+					anyIPChange = true
+				}
 			}
 		}
 	}
 
+	if !anyUpdate {
+		fmt.Fprintln(os.Stderr, "dipper_ai update: all domains up to date, skipping DDNS")
+	}
+
+	// Touch gates after processing.
 	if ddnsGate != nil {
 		_ = ddnsGate.Touch()
 	}
+	if forceSync {
+		_ = updateGate.Touch()
+	}
 
 	// --- Email notification ---
-	// Send only when the relevant flag is set and at least one provider succeeded.
-	wantMail := cfg.EmailAddr != "" && len(successLines) > 0 &&
-		((ipChanged && cfg.EmailChkDDNS) || (!ipChanged && cfg.EmailUpDDNS))
-	if wantMail {
-		if mailErr := sendUpdateNotification(cfg, fetched, ipChanged, successLines); mailErr != nil {
-			_ = st.AppendError(fmt.Sprintf("update_mail_failed: %v", mailErr))
-			fmt.Fprintf(os.Stderr, "dipper_ai update: mail notification failed: %v\n", mailErr)
-			// Mail failure is non-fatal; do not override updateErr.
+	if cfg.EmailAddr != "" && len(successLines) > 0 {
+		wantMail := (anyIPChange && cfg.EmailChkDDNS) || (anyKeepAlive && cfg.EmailUpDDNS)
+		if wantMail {
+			// Use anyIPChange as the "reason" flag for the mail body.
+			if mailErr := sendUpdateNotification(cfg, fetched, anyIPChange, successLines); mailErr != nil {
+				_ = st.AppendError(fmt.Sprintf("update_mail_failed: %v", mailErr))
+				fmt.Fprintf(os.Stderr, "dipper_ai update: mail notification failed: %v\n", mailErr)
+			}
 		}
 	}
 

--- a/internal/mode/update_test.go
+++ b/internal/mode/update_test.go
@@ -177,18 +177,18 @@ func TestUpdate_IPv6FetchFail_IPv4Proceeds(t *testing.T) {
 	}
 }
 
-// TestUpdate_Keepalive verifies that when DDNS_TIME elapses, DDNS is updated
-// even when the IP has not changed.  This is the "keepalive" behaviour that
-// restores externally reset DDNS records.
+// TestUpdate_Keepalive verifies that when UPDATE_TIME elapses, all MyDNS entries
+// are force-updated even when the IP has not changed (MyDNS keepalive).
 func TestUpdate_Keepalive(t *testing.T) {
 	cfg := baseCfg(t)
-	cfg.DDNSTime = 1 // enable keepalive for this test
+	// DDNSTime=0: no rate limit. UpdateTime=1: keepalive gate interval.
+	cfg.UpdateTime = 1
 	cfg.MyDNS = []config.MyDNSEntry{{ID: "id0", Pass: "pass0", Domain: "home.example.com", IPv4: true}}
 
 	overrideFetch(t, fakeFetch("1.2.3.4", ""))
 	calls := captureMyDNSCalls(t)
 
-	// First run — IP written to cache, DDNS called, gate_ddns touched.
+	// First run — per-domain cache empty (0.0.0.0) → IP changed → DDNS called, gate_update touched.
 	if err := Update(cfg); err != nil {
 		t.Fatalf("first run: %v", err)
 	}
@@ -197,23 +197,63 @@ func TestUpdate_Keepalive(t *testing.T) {
 		t.Fatal("expected DDNS call on first run")
 	}
 
-	// Second run — same IP, gate_ddns still active → skip.
+	// Second run — same IP, gate_update still active → no forceSync → skip.
 	if err := Update(cfg); err != nil {
 		t.Fatalf("second run: %v", err)
 	}
 	if len(*calls) != after1 {
-		t.Errorf("expected no DDNS call when IP unchanged and gate active")
+		t.Errorf("expected no DDNS call when IP unchanged and UPDATE_TIME gate active")
 	}
 
-	// Remove gate_ddns to simulate DDNS_TIME elapsed.
-	_ = os.Remove(cfg.StateDir + "/gate_ddns")
+	// Remove gate_update to simulate UPDATE_TIME elapsed.
+	_ = os.Remove(cfg.StateDir + "/gate_update")
 
-	// Third run — same IP, but DDNS_TIME elapsed → keepalive → DDNS must fire.
+	// Third run — same IP, but UPDATE_TIME elapsed → forceSync → MyDNS must fire.
 	if err := Update(cfg); err != nil {
 		t.Fatalf("keepalive run: %v", err)
 	}
 	if len(*calls) <= after1 {
-		t.Errorf("expected keepalive DDNS call when DDNS_TIME elapsed (IP unchanged)")
+		t.Errorf("expected keepalive DDNS call when UPDATE_TIME elapsed (IP unchanged)")
+	}
+}
+
+// TestUpdate_CloudflareNoKeepalive verifies that Cloudflare entries are NOT
+// updated on UPDATE_TIME keepalive — only on IP change.
+func TestUpdate_CloudflareNoKeepalive(t *testing.T) {
+	cfg := baseCfg(t)
+	cfg.UpdateTime = 1
+	cfCalls := &[]string{}
+	origCF := cloudflareUpdate
+	cloudflareUpdate = func(e ddns.CloudflareEntry, ip, recType, url string) ddns.ProviderResult {
+		*cfCalls = append(*cfCalls, recType+":"+e.Domain)
+		return ddns.ProviderResult{}
+	}
+	t.Cleanup(func() { cloudflareUpdate = origCF })
+
+	cfg.Cloudflare = []config.CloudflareEntry{
+		{Enabled: true, API: "tok", Zone: "example.com", Domain: "home.example.com", IPv4: true},
+	}
+
+	overrideFetch(t, fakeFetch("1.2.3.4", ""))
+
+	// First run: cache empty → IP changed → CF updated.
+	if err := Update(cfg); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	after1 := len(*cfCalls)
+	if after1 == 0 {
+		t.Fatal("expected CF call on first run (IP changed)")
+	}
+
+	// Remove gate_update to simulate UPDATE_TIME elapsed.
+	_ = os.Remove(cfg.StateDir + "/gate_update")
+
+	// Second run: same IP, UPDATE_TIME elapsed → forceSync → MyDNS fires but CF must NOT.
+	if err := Update(cfg); err != nil {
+		t.Fatalf("keepalive run: %v", err)
+	}
+	if len(*cfCalls) != after1 {
+		t.Errorf("Cloudflare must NOT be updated on keepalive (forceSync); got %d extra calls", len(*cfCalls)-after1)
 	}
 }
 
@@ -324,7 +364,7 @@ func TestUpdate_Mail_IPChanged(t *testing.T) {
 // keepalive updates (IP unchanged, DDNS_TIME elapsed), not on IP-change runs.
 func TestUpdate_Mail_Keepalive(t *testing.T) {
 	cfg := baseCfg(t)
-	cfg.DDNSTime = 1 // enable keepalive so the second run triggers it
+	cfg.UpdateTime = 1 // keepalive gate interval
 	cfg.EmailAddr = "test@example.com"
 	cfg.EmailUpDDNS = true // notify on keepalive only
 	cfg.EmailChkDDNS = false
@@ -342,10 +382,10 @@ func TestUpdate_Mail_Keepalive(t *testing.T) {
 		t.Errorf("no mail expected on IP-change run when EMAIL_CHK_DDNS=false, got %d", len(*sent))
 	}
 
-	// Simulate DDNS_TIME elapsed.
-	_ = os.Remove(cfg.StateDir + "/gate_ddns")
+	// Simulate UPDATE_TIME elapsed (keepalive).
+	_ = os.Remove(cfg.StateDir + "/gate_update")
 
-	// Second run: same IP, keepalive → EMAIL_UP_DDNS=true → mail expected.
+	// Second run: same IP, UPDATE_TIME elapsed → forceSync → EMAIL_UP_DDNS=true → mail expected.
 	if err := Update(cfg); err != nil {
 		t.Fatalf("keepalive run: %v", err)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -44,6 +44,39 @@ func (m *Manager) WriteIP(key, ip string) error {
 	return os.WriteFile(m.path("ip_"+key), []byte(ip+"\n"), 0644)
 }
 
+// ReadDomainCache returns the last IP sent to a specific provider domain.
+// entryKey examples: "mydns_0", "cf_0".
+// family: "ipv4" or "ipv6" (or record type "A" / "AAAA" for Cloudflare).
+// Returns "0.0.0.0" / "::" when not yet sent so the first run always updates.
+func (m *Manager) ReadDomainCache(entryKey, family string) (string, error) {
+	data, err := os.ReadFile(m.path("cache_" + entryKey + "_" + family))
+	if os.IsNotExist(err) {
+		if family == "ipv6" || family == "AAAA" {
+			return "::", nil
+		}
+		return "0.0.0.0", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// WriteDomainCache persists the last-sent IP for a specific provider domain.
+func (m *Manager) WriteDomainCache(entryKey, family, ip string) error {
+	return os.WriteFile(m.path("cache_"+entryKey+"_"+family), []byte(ip+"\n"), 0644)
+}
+
+// ResetDomainCache resets a domain's cache to the zero value, so the next
+// update run treats it as an IP change and re-sends to that provider.
+func (m *Manager) ResetDomainCache(entryKey, family string) error {
+	zero := "0.0.0.0"
+	if family == "ipv6" || family == "AAAA" {
+		zero = "::"
+	}
+	return m.WriteDomainCache(entryKey, family, zero)
+}
+
 // ReadDDNSResult returns the last DDNS result for the given provider+domain key.
 func (m *Manager) ReadDDNSResult(key string) (string, error) {
 	data, err := os.ReadFile(m.path("ddns_" + key))


### PR DESCRIPTION
## 概要

issue #32 の対応。per-domain IP キャッシュ設計への全面リファクタリング。

## 変更内容

### `internal/state/state.go`
- `ReadDomainCache(entryKey, family)` 追加 — プロバイダ×ドメイン単位のキャッシュ読み取り
- `WriteDomainCache(entryKey, family, ip)` 追加 — キャッシュ書き込み
- `ResetDomainCache(entryKey, family)` 追加 — キャッシュをゼロ値にリセット（check.go 用）

### `internal/mode/update.go`
- **DDNS_TIME**: 外側レートリミッターとして整理（0=無制限）
- **UPDATE_TIME**: MyDNS のみ keepalive ゲート（`forceSync`）として整理
- **Cloudflare**: keepalive なし — IP 変化時のみ更新
- **MyDNS**: per-domain キャッシュ比較 + `forceSync` で更新
- `anyIPChange` / `anyKeepAlive` を個別追跡してメール通知ロジックに反映

### `internal/mode/check.go`
- ミスマッチ検出時に per-domain キャッシュをリセット
- `gate_ddns` を削除して `Update()` が DDNS_TIME に遮断されないよう修正

### テスト
- `TestUpdate_Keepalive`: UPDATE_TIME ゲートベースに変更
- `TestUpdate_CloudflareNoKeepalive`: 新規追加（CF は keepalive 対象外の確認）
- `TestUpdate_PerDomain_OnlyChangedEntry`: 変更があったドメインのみ更新されることを確認
- メール通知テスト: `anyIPChange` / `anyKeepAlive` 追跡に対応

Closes #32