### PR TITLE
fix(install): DDNS_TIME に合わせて systemd タイマー間隔を動的設定 (issue #36)

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -78,6 +78,19 @@ systemctl status dipper_ai.timer
 sudo dipper_ai update
 ```
 
+> **`DDNS_TIME` と systemd タイマー間隔について**
+>
+> `install.sh` は `user.conf` の `DDNS_TIME`（分）を読み取り、
+> `OnUnitActiveSec` を自動的に設定します。
+> 設定ファイルを編集して `DDNS_TIME` を変更した場合は、
+> タイマーに反映させるために `sudo bash scripts/install.sh` を再実行してください。
+>
+> | `DDNS_TIME` | タイマー間隔 |
+> |-------------|-------------|
+> | `0`（デフォルト・無効） | 5 分（フォールバック） |
+> | `1` | 1 分 |
+> | `5` | 5 分 |
+
 ---
 
 ## アップデート
@@ -97,7 +110,7 @@ sudo bash scripts/install.sh
 |----------|------|
 | `git pull` | 最新のソースコードを取得 |
 | `go build ...` | バイナリを再ビルド |
-| `sudo bash scripts/install.sh` | バイナリと systemd unit を上書きインストール・タイマー再起動 |
+| `sudo bash scripts/install.sh` | バイナリと systemd unit を上書きインストール・`DDNS_TIME` に合わせてタイマー間隔を再設定・タイマー再起動 |
 
 > **Note:** 設定ファイル (`/etc/dipper_ai/user.conf`) はインストールスクリプトで上書きされません。設定は引き継がれます。
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,9 +34,38 @@ if [[ ! -f "$CONF_DIR/user.conf" ]]; then
   fi
 fi
 
-echo "Installing systemd units..."
+# --- Determine DDNS_TIME for systemd timer interval ---
+# Read DDNS_TIME (integer minutes) from user.conf.
+# Priority: /etc/dipper_ai/user.conf > ./user.conf > default (5 min).
+# DDNS_TIME=0 means "no rate-limit gate" — fall back to 5-minute default.
+DDNS_TIME_MIN=5
+for conf_candidate in "$CONF_DIR/user.conf" "./user.conf"; do
+  if [[ -f "$conf_candidate" ]]; then
+    v=$(grep -E '^DDNS_TIME=' "$conf_candidate" 2>/dev/null | tail -1 | cut -d= -f2 | sed 's/[[:space:]#].*//')
+    if [[ "$v" =~ ^[1-9][0-9]*$ ]]; then
+      DDNS_TIME_MIN="$v"
+    fi
+    break
+  fi
+done
+
+echo "Installing systemd units (DDNS_TIME=${DDNS_TIME_MIN}min)..."
 install -m 0644 ./systemd/dipper_ai.service "$SYSTEMD_DIR/"
-install -m 0644 ./systemd/dipper_ai.timer   "$SYSTEMD_DIR/"
+
+# Generate the timer with the interval derived from DDNS_TIME.
+# OnBootSec=2min gives the system a short warm-up period after boot.
+cat > "$SYSTEMD_DIR/dipper_ai.timer" <<EOF
+[Unit]
+Description=dipper_ai DDNS manager timer
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=${DDNS_TIME_MIN}min
+Unit=dipper_ai.service
+
+[Install]
+WantedBy=timers.target
+EOF
 
 systemctl daemon-reload
 systemctl enable --now dipper_ai.timer


### PR DESCRIPTION
## 問題

`systemd/dipper_ai.timer` の `OnUnitActiveSec=5min` が固定値のため、
`DDNS_TIME=1` にしても実際は 5 分間隔でしかチェックされなかった（issue #36）。

## 修正

`scripts/install.sh` が `user.conf` から `DDNS_TIME`（整数・分）を読み取り、
`OnUnitActiveSec` を動的に設定するようにした。

```
DDNS_TIME=0（デフォルト/無効） → OnUnitActiveSec=5min（フォールバック）
DDNS_TIME=1                    → OnUnitActiveSec=1min
DDNS_TIME=5                    → OnUnitActiveSec=5min
```

`DDNS_TIME` を変更したあとは `sudo bash scripts/install.sh` を再実行することで
タイマー間隔が更新される。

## ドキュメント更新

`docs/Installation.md` に `DDNS_TIME` とタイマー間隔の対応表を追記。

Closes #36