### PR TITLE
fix(update,check): 無更新時はログを出力しない (issue #44)

### DIFF
--- a/internal/mode/check.go
+++ b/internal/mode/check.go
@@ -71,8 +71,6 @@ func Check(cfg *config.Config) error {
 				fmt.Fprintf(os.Stderr, "dipper_ai check: %s A=%s want=%s → mismatch\n", m.Domain, registered, fetched.IPv4)
 				mydnsMismatch[i].ipv4 = true
 				mismatch = true
-			} else {
-				fmt.Fprintf(os.Stderr, "dipper_ai check: %s A=%s ok\n", m.Domain, registered)
 			}
 		}
 		if wantV6 && m.IPv6 && fetched.IPv6 != "" {
@@ -85,8 +83,6 @@ func Check(cfg *config.Config) error {
 				fmt.Fprintf(os.Stderr, "dipper_ai check: %s AAAA=%s want=%s → mismatch\n", m.Domain, registered, fetched.IPv6)
 				mydnsMismatch[i].ipv6 = true
 				mismatch = true
-			} else {
-				fmt.Fprintf(os.Stderr, "dipper_ai check: %s AAAA=%s ok\n", m.Domain, registered)
 			}
 		}
 	}
@@ -106,8 +102,6 @@ func Check(cfg *config.Config) error {
 				fmt.Fprintf(os.Stderr, "dipper_ai check: %s A=%s want=%s → mismatch\n", cf.Domain, registered, fetched.IPv4)
 				cfMismatch[i].ipv4 = true
 				mismatch = true
-			} else {
-				fmt.Fprintf(os.Stderr, "dipper_ai check: %s A=%s ok\n", cf.Domain, registered)
 			}
 		}
 		if wantV6 && cf.IPv6 && fetched.IPv6 != "" {
@@ -120,14 +114,12 @@ func Check(cfg *config.Config) error {
 				fmt.Fprintf(os.Stderr, "dipper_ai check: %s AAAA=%s want=%s → mismatch\n", cf.Domain, registered, fetched.IPv6)
 				cfMismatch[i].ipv6 = true
 				mismatch = true
-			} else {
-				fmt.Fprintf(os.Stderr, "dipper_ai check: %s AAAA=%s ok\n", cf.Domain, registered)
 			}
 		}
 	}
 
 	if !mismatch {
-		fmt.Fprintln(os.Stderr, "dipper_ai check: all domains match current IP")
+		// All domains are correct — silent exit keeps the systemd journal clean.
 		return nil
 	}
 

--- a/internal/mode/update.go
+++ b/internal/mode/update.go
@@ -73,13 +73,6 @@ func Update(cfg *config.Config) error {
 		return fetched.ErrIPv6
 	}
 
-	if fetched.IPv4 != "" {
-		fmt.Fprintf(os.Stderr, "dipper_ai update: IPv4=%s\n", fetched.IPv4)
-	}
-	if fetched.IPv6 != "" {
-		fmt.Fprintf(os.Stderr, "dipper_ai update: IPv6=%s\n", fetched.IPv6)
-	}
-
 	// --- UPDATE_TIME gate: MyDNS keepalive ---
 	// When elapsed, all MyDNS entries are force-updated regardless of IP change.
 	// Cloudflare is excluded — its records persist without periodic refresh.
@@ -115,8 +108,7 @@ func Update(cfg *config.Config) error {
 				} else {
 					_ = st.WriteDomainCache(entryKey, "ipv4", fetched.IPv4)
 					_ = st.WriteDDNSResult(entryKey+"_ipv4", "ok")
-					fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv4: ok\n", i, entry.Domain)
-					successLines = append(successLines, fmt.Sprintf("  mydns[%d] %s ipv4: ok", i, entry.Domain))
+					successLines = append(successLines, fmt.Sprintf(" mydns[%d] %s ipv4: ok", i, entry.Domain))
 					anyUpdate = true
 					if ipDiffers {
 						anyIPChange = true
@@ -140,8 +132,7 @@ func Update(cfg *config.Config) error {
 				} else {
 					_ = st.WriteDomainCache(entryKey, "ipv6", fetched.IPv6)
 					_ = st.WriteDDNSResult(entryKey+"_ipv6", "ok")
-					fmt.Fprintf(os.Stderr, "dipper_ai update: mydns[%d] %s ipv6: ok\n", i, entry.Domain)
-					successLines = append(successLines, fmt.Sprintf("  mydns[%d] %s ipv6: ok", i, entry.Domain))
+					successLines = append(successLines, fmt.Sprintf(" mydns[%d] %s ipv6: ok", i, entry.Domain))
 					anyUpdate = true
 					if ipDiffers {
 						anyIPChange = true
@@ -178,8 +169,7 @@ func Update(cfg *config.Config) error {
 				} else {
 					_ = st.WriteDomainCache(entryKey, "A", fetched.IPv4)
 					_ = st.WriteDDNSResult(entryKey+"_A", "ok")
-					fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s A: ok\n", i, cf.Domain)
-					successLines = append(successLines, fmt.Sprintf("  cf[%d] %s A: ok", i, cf.Domain))
+					successLines = append(successLines, fmt.Sprintf(" cf[%d] %s A: ok", i, cf.Domain))
 					anyUpdate = true
 					anyIPChange = true
 				}
@@ -198,8 +188,7 @@ func Update(cfg *config.Config) error {
 				} else {
 					_ = st.WriteDomainCache(entryKey, "AAAA", fetched.IPv6)
 					_ = st.WriteDDNSResult(entryKey+"_AAAA", "ok")
-					fmt.Fprintf(os.Stderr, "dipper_ai update: cf[%d] %s AAAA: ok\n", i, cf.Domain)
-					successLines = append(successLines, fmt.Sprintf("  cf[%d] %s AAAA: ok", i, cf.Domain))
+					successLines = append(successLines, fmt.Sprintf(" cf[%d] %s AAAA: ok", i, cf.Domain))
 					anyUpdate = true
 					anyIPChange = true
 				}
@@ -207,8 +196,18 @@ func Update(cfg *config.Config) error {
 		}
 	}
 
-	if !anyUpdate {
-		fmt.Fprintln(os.Stderr, "dipper_ai update: all domains up to date, skipping DDNS")
+	// Log only when at least one update was attempted.
+	// Silent output when nothing changed keeps the systemd journal clean.
+	if anyUpdate {
+		if fetched.IPv4 != "" {
+			fmt.Fprintf(os.Stderr, "dipper_ai update: IPv4=%s\n", fetched.IPv4)
+		}
+		if fetched.IPv6 != "" {
+			fmt.Fprintf(os.Stderr, "dipper_ai update: IPv6=%s\n", fetched.IPv6)
+		}
+		for _, line := range successLines {
+			fmt.Fprintf(os.Stderr, "dipper_ai update:%s\n", line)
+		}
 	}
 
 	// Touch gates after processing.


### PR DESCRIPTION
## 問題

IP が変化していなくても毎回 `dipper_ai update: IPv4=xxx` や
`dipper_ai update: mydns[0] xxx ipv4: ok` がログに出力され、
systemd journal がノイズで埋まっていた（issue #44）。

## 修正

**update モード**
- IP アドレス（IPv4/IPv6）の表示を更新が発生したときのみに移動
- ループ内の個別 "ok" ログを削除し、末尾にまとめて出力するよう一本化
- "all domains up to date" メッセージを削除（無更新時は完全無音）

**check モード**
- 全ドメイン一致時の "all domains match" メッセージを削除
- ドメインごとの "A=xxx ok" 行を削除
- 不整合検知・更新トリガーのメッセージは保持

## 結果

| 状況 | 出力 |
|------|------|
| IP 変化なし・更新なし | **無音** |
| IP 変化あり・更新あり | IPv4/IPv6 + 更新ドメイン一覧 |
| エラー発生 | エラーメッセージ |

Closes #44